### PR TITLE
d2l-outcomes-level-of-achievements demo

### DIFF
--- a/demo/data/outcomes/level-1.json
+++ b/demo/data/outcomes/level-1.json
@@ -11,7 +11,7 @@
             "rel": [
                 "self"
             ],
-            "href": "data/level-1.json"
+            "href": "data/outcomes/level-1.json"
         }
     ]
 }

--- a/demo/data/outcomes/level-1.json
+++ b/demo/data/outcomes/level-1.json
@@ -1,0 +1,17 @@
+{
+    "class": [
+        "level-of-achievment"
+    ],
+    "properties": {
+        "name": "Level 1",
+        "color": "#FF0000"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/level-1.json"
+        }
+    ]
+}

--- a/demo/data/outcomes/level-2.json
+++ b/demo/data/outcomes/level-2.json
@@ -11,7 +11,7 @@
             "rel": [
                 "self"
             ],
-            "href": "data/levels/level-2.json"
+            "href": "data/outcomes/level-2.json"
         }
     ]
 }

--- a/demo/data/outcomes/level-2.json
+++ b/demo/data/outcomes/level-2.json
@@ -1,0 +1,17 @@
+{
+    "class": [
+        "level-of-achievment"
+    ],
+    "properties": {
+        "name": "Level 2",
+        "color": "#FFFF00"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/levels/level-2.json"
+        }
+    ]
+}

--- a/demo/data/outcomes/level-3.json
+++ b/demo/data/outcomes/level-3.json
@@ -1,0 +1,17 @@
+{
+    "class": [
+        "level-of-achievment"
+    ],
+    "properties": {
+        "name": "Level 3",
+        "color": "#00FF00"
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/levels/level-3.json"
+        }
+    ]
+}

--- a/demo/data/outcomes/level-3.json
+++ b/demo/data/outcomes/level-3.json
@@ -11,7 +11,7 @@
             "rel": [
                 "self"
             ],
-            "href": "data/levels/level-3.json"
+            "href": "data/outcomes/level-3.json"
         }
     ]
 }

--- a/demo/data/outcomes/suggested-level.json
+++ b/demo/data/outcomes/suggested-level.json
@@ -1,0 +1,125 @@
+{
+    "class": [
+        "demonstration"
+    ],
+    "entities": [
+        {
+            "class": [
+                "demonstratable-level"
+            ],
+            "rel": [
+                "item"
+            ],
+            "actions": [
+                {
+                    "type": "application/json",
+                    "href": "#",
+                    "name": "select",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "levelId",
+                            "value": "1"
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "select",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://achievements.api.brightspace.com/rels/level"
+                    ],
+                    "href": "data/outcomes/level-1.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "demonstratable-level",
+                "suggested",
+                "selected"
+            ],
+            "rel": [
+                "item"
+            ],
+            "actions": [
+                {
+                    "type": "application/json",
+                    "href": "#",
+                    "name": "deselect",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "levelId",
+                            "value": "2"
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "select",
+                            "value": false
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://achievements.api.brightspace.com/rels/level"
+                    ],
+                    "href": "data/outcomes/level-2.json"
+                }
+            ]
+        },
+        {
+            "class": [
+                "demonstratable-level"
+            ],
+            "rel": [
+                "item"
+            ],
+            "actions": [
+                {
+                    "type": "application/json",
+                    "href": "#",
+                    "name": "select",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "levelId",
+                            "value": "3"
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "select",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://achievements.api.brightspace.com/rels/level"
+                    ],
+                    "href": "data/outcomes/level-3.json"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/outcomes/3-levels.json"
+        }
+    ]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../consistent-evaluation.js';
-			import "d2l-outcomes-level-of-achievements/d2l-outcomes-level-of-achievements.js"
+			import 'd2l-outcomes-level-of-achievements/d2l-outcomes-level-of-achievements.js';
 		</script>
 		<title>d2l-consistent-evaluation</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,6 +6,7 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../consistent-evaluation.js';
+			import "d2l-outcomes-level-of-achievements/d2l-outcomes-level-of-achievements.js"
 		</script>
 		<title>d2l-consistent-evaluation</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,6 +18,29 @@
 			<h2>d2l-consistent-evaluation</h2>
 			<d2l-demo-snippet>
 				<d2l-consistent-evaluation></d2l-consistent-evaluation>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+
+		<d2l-demo-page page-title="d2l-outcomes-level-of-achievements">
+			<h2>d2l-outcomes-level-of-achievements</h2>
+			<d2l-demo-snippet>
+				<div style="margin: 10px">
+					<p>The text above the suggestion goes here</p>
+					<d2l-outcomes-level-of-achievements href="data/outcomes/suggested-level.json" token="abc123" />
+				</div>
+			</d2l-demo-snippet>
+			<d2l-demo-snippet>
+				<d2l-template-primary-secondary>
+					<p slot="header">header</p>
+					<p slot="primary">primary</p>
+					<div slot="secondary">
+						<div style="margin: 10px">
+						<p>The text above the suggestion goes here</p>
+						<d2l-outcomes-level-of-achievements href="data/outcomes/suggested-level.json" token="abc123"/>            
+					</div>
+					</div>
+					<p slot="footer">footer</p>
+				</d2l-template-primary-secondary>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,8 +2594,8 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git#a3b67dc058d21dcf4c8b26abd4863af676bbb3ba",
-      "from": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#a3b67dc058d21dcf4c8b26abd4863af676bbb3ba",
+      "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:2",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "d2l-colors": "github:BrightspaceUI/colors#semver:^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1117,6 +1117,30 @@
         "mocha": "^6.2.2"
       }
     },
+    "@polymer/iron-ajax": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-ajax/-/iron-ajax-3.0.1.tgz",
+      "integrity": "sha512-7+TPEAfWsRdhj1Y8UeF1759ktpVu+c3sG16rJiUC3wF9+woQ9xI1zUm2d59i7Yc3aDEJrR/Q8Y262KlOvyGVNg==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-resizable-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
+      "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/polymer": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.3.1.tgz",
+      "integrity": "sha512-8KaB48tzyMjdsHdxo5KvCAaqmTe7rYDzQAoj/pyEfq9Fp4YfUaS+/xqwYj0GbiDAUNzwkmEQ7dw9cgnRNdKO8A==",
+      "requires": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz",
@@ -2543,6 +2567,83 @@
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
+    "d2l-colors": {
+      "version": "github:BrightspaceUI/colors#e5697963f1f742428c9ef4d79e6324f35ef131a3",
+      "from": "github:BrightspaceUI/colors#semver:^4",
+      "requires": {
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "d2l-fetch": {
+      "version": "github:Brightspace/d2l-fetch#d2b14d7bfad9050fdf4eea6f42ec91f0b3e18de4",
+      "from": "github:Brightspace/d2l-fetch#semver:^2"
+    },
+    "d2l-hypermedia-constants": {
+      "version": "github:Brightspace/d2l-hypermedia-constants#3d2291ef284591d26e2ea93bb76e363a0bbf7814",
+      "from": "github:Brightspace/d2l-hypermedia-constants#semver:^6"
+    },
+    "d2l-localize-behavior": {
+      "version": "github:BrightspaceUI/localize-behavior#154bbc671e3a3f354bf0aad8c20f63cbfb6038a0",
+      "from": "github:BrightspaceUI/localize-behavior#semver:^2",
+      "requires": {
+        "@brightspace-ui/intl": "^3",
+        "@polymer/iron-ajax": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3",
+        "intl-messageformat": "^7"
+      }
+    },
+    "d2l-outcomes-level-of-achievements": {
+      "version": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git#a3b67dc058d21dcf4c8b26abd4863af676bbb3ba",
+      "from": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "d2l-hypermedia-constants": "github:Brightspace/d2l-hypermedia-constants#semver:^6",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+        "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "fastdom": "^1.0.8"
+      }
+    },
+    "d2l-polymer-behaviors": {
+      "version": "github:Brightspace/d2l-polymer-behaviors-ui#09d3f471d93d9c26dbdfbced796f21070e692ec6",
+      "from": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+      "requires": {
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3.0.0",
+        "fastdom": "^1.0.8"
+      }
+    },
+    "d2l-polymer-siren-behaviors": {
+      "version": "github:Brightspace/polymer-siren-behaviors#b944c4b0cf9293204d4cf0b5c122eba651c6f5a4",
+      "from": "github:Brightspace/polymer-siren-behaviors#semver:^1",
+      "requires": {
+        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
+        "fastdom": "^1.0.8",
+        "siren-parser": "^8.0.0"
+      }
+    },
+    "d2l-tooltip": {
+      "version": "github:BrightspaceUI/tooltip#fb4ac53db317dad3d1056808025358d7905acc41",
+      "from": "github:BrightspaceUI/tooltip#semver:^3",
+      "requires": {
+        "@brightspace-ui/core": "^1",
+        "@polymer/iron-resizable-behavior": "^3.0.0",
+        "@polymer/polymer": "^3.0.0",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+      }
+    },
+    "d2l-typography": {
+      "version": "github:BrightspaceUI/typography#e130a5a93a83f896d2715cef94e70e870e2cb2b5",
+      "from": "github:BrightspaceUI/typography#semver:^7",
+      "requires": {
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3786,6 +3887,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastdom": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.9.tgz",
+      "integrity": "sha512-SSp4fbVzu8JkkG01NUX+0iOwe9M5PN3MGIQ84txLf4TkkJG4q30khkzumKgi4hUqO1+jX6wLHfnCPoZ6eSZ6Tg==",
+      "requires": {
+        "strictdom": "^1.0.1"
+      }
     },
     "fastq": {
       "version": "1.6.0",
@@ -7911,6 +8020,11 @@
       "integrity": "sha512-BpVxsjEkGi6XPbDXrgWUe7Cb1ZzIfxKUbu/MmH5RoUnS7AXpKo3aIYIyQUg0FMvlUL05aPt7VZuAdaeQhEnWxg==",
       "dev": true
     },
+    "siren-parser": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/siren-parser/-/siren-parser-8.2.0.tgz",
+      "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -8321,6 +8435,11 @@
         "fs-extra": "^7.0.1",
         "lodash": "^4.17.14"
       }
+    },
+    "strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha1-GJ3pFkn3PUTVm4Qy76aO+dJllGA="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "@webcomponents/webcomponentsjs": "^2",
-    "d2l-outcomes-level-of-achievements": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git",
+    "d2l-outcomes-level-of-achievements": "github:Brightspace/outcomes-level-of-achievement-ui#semver:2",
     "lit-element": "^2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "@webcomponents/webcomponentsjs": "^2",
+    "d2l-outcomes-level-of-achievements": "git+https://github.com/Brightspace/outcomes-level-of-achievement-ui.git",
     "lit-element": "^2"
   }
 }


### PR DESCRIPTION

Here is a demo of the d2l-outcomes-level-of-achievements component. It appears to be responsive to the sidebar changing sizes. The data structure for it is fairly simple. There is just an array of options with text and colors, then a suggested text above that.

![image](https://user-images.githubusercontent.com/20796985/74065037-fb308c00-49c1-11ea-8597-2539432c9a88.png)

![image](https://user-images.githubusercontent.com/20796985/74065049-fff54000-49c1-11ea-8cd0-47d717cb255d.png)

![Design Concept - Frame](https://user-images.githubusercontent.com/20796985/74065534-25367e00-49c3-11ea-928f-f0f9f24aa4aa.png)