### PR TITLE
default increment is already specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
     npm run test:headless || travis_terminate 1;
   fi
 after_success:
-- frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
+- frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
 env:
   global:
   - SAUCE_USERNAME: Desire2Learn


### PR DESCRIPTION
trying to figure out why frau-ci isn't auto-releasing after a merge

for this specific PR, the `-d` flag is already specified in the travis variable `DEFAULT_INCREMENT` so it was redundant