### PR TITLE
Get travis to auto release on tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ script:
   fi
 after_success:
 - frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
   - SAUCE_USERNAME: Desire2Learn


### PR DESCRIPTION
I think BSI only looks for releases and not just tags so adding this code from `activities` to auto release on tagged builds.