### PR TITLE
updating travis.yml to include build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,30 @@ language: node_js
 node_js: node
 addons:
   chrome: stable
-script:
-- npm run lint
-- |
-  if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
-    echo "Pull request with secure environment variables, running Sauce tests...";
-    npm run test:sauce || travis_terminate 1;
-  else
-    echo "Not a pull request and/or no secure environment variables, running headless tests...";
-    npm run test:headless || travis_terminate 1;
-  fi
-- |
-  if [ $TRAVIS_SECURE_ENV_VARS == true ]; then
-    echo "Running visual difference tests...";
-    npm run test:diff || travis_terminate 1;
-  fi
-after_success:
-- frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
+
+jobs:
+  include:
+  - stage: code-tests
+    script:
+    - npm run lint
+    - |
+      if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
+        echo "Pull request with secure environment variables, running Sauce tests...";
+        npm run test:sauce || travis_terminate 1;
+      else
+        echo "Not a pull request and/or no secure environment variables, running headless tests...";
+        npm run test:headless || travis_terminate 1;
+      fi
+  - stage: visual-difference-tests
+    script:
+    - |
+      if [ $TRAVIS_SECURE_ENV_VARS == true ]; then
+        echo "Running visual difference tests...";
+        npm run test:diff || travis_terminate 1;
+      fi
+  - stage: update-version
+    script: frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
+
 deploy:
   provider: releases
   api_key: "$GITHUB_RELEASE_TOKEN"


### PR DESCRIPTION
This PR is for breaking the build into stages so that it will work with the visual difference bot. This is a prerequisite to setting up the bot.

Once this PR is approved, someone with the proper authorization for `BrightspaceHypermediaComponents` as an `"owner"` can install the bot by following **step one** [here](https://github.com/BrightspaceUI/visual-difference-bot/blob/master/README.md#setting-up-the-bot-on-your-existing-brightspace-repo). @AlexBedley I think you should have permissions since you created the repo.
