### PR TITLE
change to proper property and attribute binding

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -4,8 +4,10 @@ import './left-panel/consistent-evaluation-submissions-page.js';
 import '@brightspace-ui/core/components/inputs/input-text.js';
 import '@brightspace-ui/core/templates/primary-secondary/primary-secondary.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { evaluationRel, publishedState } from './controllers/constants.js';
+import { draftState, publishedState } from './controllers/constants.js';
+import { Grade, GradeType } from '@brightspace-ui-labs/grade-result/src/controller/Grade';
 import { ConsistentEvaluationController } from './controllers/ConsistentEvaluationController.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export default class ConsistentEvaluationPage extends LitElement {
 
@@ -14,18 +16,6 @@ export default class ConsistentEvaluationPage extends LitElement {
 			evaluationHref: {
 				attribute: 'evaluation-href',
 				type: String
-			},
-			evaluationState: {
-				attribute: 'evaluation-state',
-				type: String
-			},
-			feedbackText: {
-				attribute: false,
-				type: String
-			},
-			grade: {
-				attribute: false,
-				type: Object
 			},
 			nextStudentHref: {
 				attribute: 'next-student-href',
@@ -51,12 +41,18 @@ export default class ConsistentEvaluationPage extends LitElement {
 				attribute: 'rubric-read-only',
 				type: Boolean
 			},
-			submissionList: {
-				attribute: 'submission-list',
-				type: Array
+			submissionInfo: {
+				attribute: false,
+				type: Object
 			},
 			token: {
 				type: String
+			},
+			_feedbackText: {
+				attribute: false
+			},
+			_grade: {
+				attribute: false
 			},
 			_feedbackEntity: {
 				attribute: false
@@ -98,7 +94,7 @@ export default class ConsistentEvaluationPage extends LitElement {
 		const oldVal = this.evaluationEntity;
 		if (oldVal !== entity) {
 			this._evaluationEntity = entity;
-			this.evaluationHref = entity.getLinkByRel(evaluationRel).href;
+			this.requestUpdate();
 		}
 	}
 
@@ -130,18 +126,18 @@ export default class ConsistentEvaluationPage extends LitElement {
 		}
 	}
 
-	get feedbackText() {
+	get _feedbackText() {
 		if (this._feedbackEntity && this._feedbackEntity.properties) {
 			return this._feedbackEntity.properties.text || '';
 		}
 		return '';
 	}
 
-	get grade() {
+	get _grade() {
 		if (this._gradeEntity) {
 			return this._controller.parseGrade(this._gradeEntity);
 		}
-		return undefined;
+		return new Grade(GradeType.Number, 0, 0, null, null, this._gradeEntity);
 	}
 
 	get _feedbackEntity() {
@@ -209,11 +205,13 @@ export default class ConsistentEvaluationPage extends LitElement {
 	async _publishEvaluation() {
 		this.evaluationEntity = await this._controller.publish(this.evaluationEntity);
 		this.evaluationState = this.evaluationEntity.properties.state;
+		this.submissionInfo.evaluationState = publishedState;
 	}
 
 	async _retractEvaluation() {
 		this.evaluationEntity = await this._controller.retract(this.evaluationEntity);
 		this.evaluationState = this.evaluationEntity.properties.state;
+		this.submissionInfo.evaluationState = draftState;
 	}
 
 	render() {
@@ -222,19 +220,19 @@ export default class ConsistentEvaluationPage extends LitElement {
 				<div slot="header"><h1>Hello, consistent-evaluation!</h1></div>
 				<div slot="primary">
 					<d2l-consistent-evaluation-submissions-page
-					.due-date=${this.submissionInfo && this.submissionInfo.dueDate}
+					due-date=${ifDefined(this.submissionInfo && this.submissionInfo.dueDate)}
 					evaluation-state=${this.submissionInfo && this.submissionInfo.evaluationState}
 					submission-type=${this.submissionInfo && this.submissionInfo.submissionType}
-					.submission-list=${this.submissionInfo && this.submissionInfo.submissionList}
+					.submissionList=${this.submissionInfo && this.submissionInfo.submissionList}
 					.token=${this.token}></d2l-consistent-evaluation-submissions-page>
 				</div>
 				<div slot="secondary">
 					<consistent-evaluation-right-panel
-						.grade=${this.grade}
-						rubric-href=${this.rubricHref}
-						rubric-assessment-href=${this.rubricAssessmentHref}
-						outcomes-href=${this.outcomesHref}
-						feedback-text=${this.feedbackText}
+						feedback-text=${this._feedbackText}
+						rubric-href=${ifDefined(this.rubricHref)}
+						rubric-assessment-href=${ifDefined(this.rubricAssessmentHref)}
+						outcomes-href=${ifDefined(this.outcomesHref)}
+						.grade=${this._grade}
 						.token=${this.token}
 						?rubric-read-only=${this.rubricReadOnly}
 						?rich-text-editor-disabled=${this.richTextEditorDisabled}
@@ -248,13 +246,13 @@ export default class ConsistentEvaluationPage extends LitElement {
 				</div>
 				<div slot="footer">
 					<d2l-consistent-evaluation-footer-presentational
+						next-student-href=${ifDefined(this.nextStudentHref)}
 						?published=${this._isEvaluationPublished()}
-						.next-student-href=${this.nextStudentHref}
-						@on-publish=${this._publishEvaluation}
-						@on-save-draft=${this._saveEvaluation}
-						@on-retract=${this._retractEvaluation}
-						@on-update=${this._updateEvaluation}
-						@on-next-student=${this._onNextStudentClick}
+						@d2l-consistent-evaluation-on-publish=${this._publishEvaluation}
+						@d2l-consistent-evaluation-on-save-draft=${this._saveEvaluation}
+						@d2l-consistent-evaluation-on-retract=${this._retractEvaluation}
+						@d2l-consistent-evaluation-on-update=${this._updateEvaluation}
+						@d2l-consistent-evaluation-on-next-student=${this._onNextStudentClick}
 					></d2l-consistent-evaluation-footer-presentational>
 				</div>
 			</d2l-template-primary-secondary>

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -1,6 +1,7 @@
 import './consistent-evaluation-page.js';
 import { ConsistentEvaluationHrefController } from './controllers/ConsistentEvaluationHrefController.js';
 import { html } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import RootStore from './stores/root.js';
 
@@ -46,12 +47,12 @@ export class ConsistentEvaluation extends MobxLitElement {
 	render() {
 		return html`
 			<d2l-consistent-evaluation-page
-				.rubric-href=${this._childHrefs && this._childHrefs.rubricHref}
-				.rubric-assessment-href=${this._childHrefs && this._childHrefs.rubricAssessmentHref}
-				.outcomes-href=${this._childHrefs && this._childHrefs.outcomesHref}
-				.evaluation-href=${this._childHrefs && this._childHrefs.evaluationHref}
-				.next-student-href=${this._childHrefs && this._childHrefs.nextHref}
-				.submission-info=${this._submissionInfo}
+				rubric-href=${ifDefined(this._childHrefs && this._childHrefs.rubricHref)}
+				rubric-assessment-href=${ifDefined(this._childHrefs && this._childHrefs.rubricAssessmentHref)}
+				outcomes-href=${ifDefined(this._childHrefs && this._childHrefs.outcomesHref)}
+				evaluation-href=${ifDefined(this._childHrefs && this._childHrefs.evaluationHref)}
+				next-student-href=${ifDefined(this._childHrefs && this._childHrefs.nextHref)}
+				.submissionInfo=${this._submissionInfo}
 				.token=${this.token}
 				?rubric-read-only=${this._rubricReadOnly}
 				?rich-text-editor-disabled=${this._richTextEditorDisabled}

--- a/components/controllers/constants.js
+++ b/components/controllers/constants.js
@@ -15,5 +15,6 @@ export const rubricRel = 'https://api.brightspace.com/rels/rubric';
 export const nextRel = 'next';
 export const previousRel = 'previous';
 export const publishedState = 'Published';
+export const draftState = 'Draft';
 export const fileSubmission = 'File submission';
 export const textSubmission = 'Text submission';

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -295,7 +295,6 @@ export class ConsistentEvaluationSubmissionItem extends LocalizeMixin(LitElement
 	}
 
 	render() {
-		console.log(this);
 		if (this.submissionType === fileSubmission) {
 			return html`${this._renderFileSubmission()}`;
 		} else if (this.submissionType === textSubmission) {

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -27,7 +27,7 @@ export class ConsistentEvaluationSubmissionItem extends LocalizeMixin(LitElement
 			},
 			displayNumber : {
 				attribute: 'display-number',
-				type: Number
+				type: String
 			},
 			evaluationState : {
 				attribute: 'evaluation-state',
@@ -81,7 +81,7 @@ export class ConsistentEvaluationSubmissionItem extends LocalizeMixin(LitElement
 
 	constructor() {
 		super();
-
+		this.late = false;
 		this._submissionEntity = undefined;
 		this._date = undefined;
 		this._attachments = [];
@@ -295,6 +295,7 @@ export class ConsistentEvaluationSubmissionItem extends LocalizeMixin(LitElement
 	}
 
 	render() {
+		console.log(this);
 		if (this.submissionType === fileSubmission) {
 			return html`${this._renderFileSubmission()}`;
 		} else if (this.submissionType === textSubmission) {

--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -11,7 +11,7 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 		return {
 			dueDate: {
 				attribute: 'due-date',
-				type: Object
+				type: String
 			},
 			evaluationState: {
 				attribute: 'evaluation-state',
@@ -106,11 +106,11 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 					itemTemplate.push(html`
 						<d2l-consistent-evaluation-submission-item
 							date-str=${submissionDate}
-							.display-number=${this._submissionEntities.length - i}
+							display-number=${this._submissionEntities.length - i}
 							evaluation-state=${this.evaluationState}
-							?late=${new Date(this.dueDate) < new Date(submissionDate)}
-							.submission-entity=${submissionEntity}
 							submission-type=${this.submissionType}
+							.submissionEntity=${submissionEntity}
+							?late=${new Date(this.dueDate) < new Date(submissionDate)}
 						></d2l-consistent-evaluation-submission-item>`);
 				} else {
 					console.warn('Consistent Evaluation submission date property not found');

--- a/components/right-panel/consistent-evaluation-grade-result.js
+++ b/components/right-panel/consistent-evaluation-grade-result.js
@@ -8,12 +8,24 @@ export class ConsistentEvaluationGradeResult extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
-			grade: { type: Object },
-			customManualOverrideText: { type: String },
-			customManualOverrideClearText: { type: String },
-			_labelText: { type: String },
-			_readOnly: { type: Boolean },
-			_hideTitle: { type: Boolean },
+			grade: {
+				attribute: false,
+				type: Object },
+			customManualOverrideText: {
+				attribute: 'custom-manual-override-text',
+				type: String },
+			customManualOverrideClearText: {
+				attribute:'custom-manual-override-clear-text',
+				type: String },
+			labelText: {
+				attribute: 'label-text',
+				type: String },
+			readOnly: {
+				attribute: 'read-only',
+				type: Boolean },
+			hideTitle: {
+				attribute: 'hide-title',
+				type: Boolean },
 
 			_manuallyOverriddenGrade: { type: Object },
 			_hasUnsavedChanged: { type: Boolean },
@@ -21,7 +33,7 @@ export class ConsistentEvaluationGradeResult extends LocalizeMixin(LitElement) {
 			_includeReportsButton: { type: Boolean },
 			_gradeButtonTooltip: { type: String },
 			_reportsButtonTooltip: { type: String },
-			_isGradeAutoCompleted: { type: Boolean },
+			_isGradeAutoCompleted: { type: Boolean }
 		};
 	}
 
@@ -30,9 +42,9 @@ export class ConsistentEvaluationGradeResult extends LocalizeMixin(LitElement) {
 		this.grade = new Grade(GradeType.Number, 0, 0, null, null, null);
 		this.customManualOverrideText = undefined;
 		this.customManualOverrideClearText = undefined;
-		this._readOnly = false;
-		this._labelText = '';
-		this._hideTitle = false;
+		this.readOnly = false;
+		this.labelText = '';
+		this.hideTitle = false;
 		// hard coded as disabled as not yet supported by API
 		this._manuallyOverriddenGrade = undefined;
 		this._hasUnsavedChanged = false;
@@ -69,7 +81,7 @@ export class ConsistentEvaluationGradeResult extends LocalizeMixin(LitElement) {
 		return html`
 			<d2l-consistent-evaluation-right-panel-block title="Overall Grade">
 			<d2l-labs-d2l-grade-result-presentational
-				labelText=${this.localize('overallGrade')}
+				labelText=${this.labelText || this.localize('overallGrade')}
 				.gradeType=${gradeType}
 				scoreNumerator=${score}
 				scoreDenominator=${scoreOutOf}
@@ -86,8 +98,8 @@ export class ConsistentEvaluationGradeResult extends LocalizeMixin(LitElement) {
 				?isGradeAutoCompleted=${this._isGradeAutoCompleted}
 				?isManualOverrideActive=${this._manuallyOverriddenGrade !== undefined}
 
-				?readOnly=${this._readOnly}
-				?hideTitle=${this._hideTitle}
+				?readOnly=${this.readOnly}
+				?hideTitle=${this.hideTitle}
 
 				@d2l-grade-result-grade-change=${this.onGradeChanged}
 				@d2l-grade-result-letter-score-selected=${this.onGradeChanged}

--- a/components/right-panel/consistent-evaluation-right-panel.js
+++ b/components/right-panel/consistent-evaluation-right-panel.js
@@ -1,8 +1,9 @@
-import './consistent-evaluation-feedback.js';
+import './consistent-evaluation-feedback-presentational.js';
 import './consistent-evaluation-outcomes.js';
 import './consistent-evaluation-rubric.js';
 import './consistent-evaluation-grade-result.js';
 import { css, html, LitElement } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { loadLocalizationResources } from '../locale.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
@@ -15,6 +16,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 				type: String
 			},
 			grade: {
+				attribute: false,
 				type: Object
 			},
 			hideRubric: {
@@ -107,7 +109,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 				<d2l-consistent-evaluation-rubric
 					header=${this.localize('rubrics')}
 					href=${this.rubricHref}
-					assessment-href=${this.rubricAssessmentHref}
+					assessment-href=${ifDefined(this.rubricAssessmentHref)}
 					.token=${this.token}
 					?read-only=${this.rubricReadOnly}
 				></d2l-consistent-evaluation-rubric>
@@ -135,7 +137,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 			return html`
 				<d2l-consistent-evaluation-feedback-presentational
 					can-edit-feedback
-					.feedback-text=${this.feedbackText}
+					feedback-text=${this.feedbackText}
 					.rich-text-editor-config=${this._richTextEditorConfig}
 					@d2l-consistent-eval-on-feedback-edit=${this._transientSaveFeedback}
 				></d2l-consistent-evaluation-feedback-presentational>


### PR DESCRIPTION
Consolidated naming convention best practices and a working consistent eval app.

For _strings_ and _bools_, pass using **attributes**:
`some-attribute`
`?some-bool`
For _objects_, pass using **property** bindings:
`.someProperty`