### PR TITLE
pass undefined when the feedback text is not defined

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -134,7 +134,7 @@ export default class ConsistentEvaluationPage extends LitElement {
 		if (this._feedbackEntity && this._feedbackEntity.properties) {
 			return this._feedbackEntity.properties.text || '';
 		}
-		return '';
+		return undefined;
 	}
 
 	get _grade() {
@@ -247,7 +247,7 @@ export default class ConsistentEvaluationPage extends LitElement {
 				<div slot="secondary">
 					<consistent-evaluation-right-panel
 						evaluation-href=${this.evaluationHref}
-						feedback-text=${this._feedbackText}
+						.feedbackText=${this._feedbackText}
 						rubric-href=${ifDefined(this.rubricHref)}
 						rubric-assessment-href=${ifDefined(this.rubricAssessmentHref)}
 						outcomes-href=${ifDefined(this.outcomesHref)}

--- a/components/right-panel/consistent-evaluation-feedback-presentational.js
+++ b/components/right-panel/consistent-evaluation-feedback-presentational.js
@@ -16,8 +16,7 @@ class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElemen
 				type: Boolean
 			},
 			feedbackText: {
-				attribute: 'feedback-text',
-				type: String
+				attribute: false
 			},
 			href: {
 				type: String
@@ -40,8 +39,6 @@ class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElemen
 		super();
 
 		this.canEditFeedback = false;
-		this.feedbackText = '';
-
 		this._debounceJobs = {};
 		this.addEventListener('d2l-request-provider',
 			e => {
@@ -71,6 +68,7 @@ class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElemen
 	}
 	render() {
 		if (this.href && this.token) {
+
 			return html`
 			<d2l-consistent-evaluation-right-panel-block title="${this.localize('overallFeedback')}">
 				<d2l-activity-text-editor

--- a/components/right-panel/consistent-evaluation-right-panel.js
+++ b/components/right-panel/consistent-evaluation-right-panel.js
@@ -12,8 +12,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 	static get properties() {
 		return {
 			feedbackText: {
-				attribute: 'feedback-text',
-				type: String
+				attribute: false
 			},
 			grade: {
 				attribute: false,
@@ -122,7 +121,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 					.href=${this.evaluationHref}
 					.token=${this.token}
 					can-edit-feedback
-					feedback-text=${this.feedbackText}
+					.feedbackText=${this.feedbackText}
 					.richTextEditorConfig=${this.richTextEditorConfig}
 				></d2l-consistent-evaluation-feedback-presentational>
 			`;


### PR DESCRIPTION
This is the unfortunate way that the html editor needs to work. It cant be initialized with a value twice. So the first time we init it, we set it to undefined now. Then when we actually have text, we set it to a value.