### PR TITLE
move @click to content to expose menu button

### DIFF
--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -307,19 +307,18 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	_renderAttachments() {
 		// href placeholder on list-item
 		return html`${this._attachments.map((file) => html`
-			<d2l-list-item 
-				href="javascript:void(0);"
-				@click="${
-	// eslint-disable-next-line lit/no-template-arrow
-	() => this._dispatchRenderEvidenceEvent(file.properties.fileViewer)}">
-
+			<d2l-list-item
+				href="javascript:void(0);">
 			<div slot="illustration" class="d2l-submission-attachment-icon-container">
 				<d2l-icon class="d2l-submission-attachment-icon-container-inner"
 					icon="tier2:${this._getIcon(file.properties.name)}"
 					aria-label="${this._getIcon(file.properties.name)}"></d2l-icon>
 				${this._renderReadStatus(file.properties.read)}
 			</div>
-			<d2l-list-item-content>
+			<d2l-list-item-content
+			@click="${
+	// eslint-disable-next-line lit/no-template-arrow
+	() => this._dispatchRenderEvidenceEvent(file.properties.fileViewer)}">
 				<span>${this._getFileTitle(file.properties.name)}</span>
 				<div slot="supporting-info">
 					${this._renderFlaggedStatus(file.properties.flagged)}


### PR DESCRIPTION
This should fix the issue where the menu button click was also opening an attachment in evidence view
https://rally1.rallydev.com/#/detail/userstory/407933700552?fdp=true