### PR TITLE
get rid of href to access list-content click

### DIFF
--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -307,8 +307,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	_renderAttachments() {
 		// href placeholder on list-item
 		return html`${this._attachments.map((file) => html`
-			<d2l-list-item
-				href="javascript:void(0);">
+			<d2l-list-item>
 			<div slot="illustration" class="d2l-submission-attachment-icon-container">
 				<d2l-icon class="d2l-submission-attachment-icon-container-inner"
 					icon="tier2:${this._getIcon(file.properties.name)}"


### PR DESCRIPTION
Get rid of the empty href on `d2l-list` that was to make hover state text styling appear, to be able to access `d2l-list-content` click handling. 