### PR TITLE
Add text truncation for attachment item filenames

### DIFF
--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -124,14 +124,13 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 			margin-right: 0;
 		}
 		.truncate {
+			text-overflow: ellipsis;
+			white-space: break-spaces;
 			overflow: hidden;
+			overflow-wrap: break-word;
 			display: -webkit-box;
-			-webkit-line-clamp: 2;
+			-webkit-line-clamp: 3;
 			-webkit-box-orient: vertical;
-		}
-		:host[dir="rtl"] .truncate {
-			padding-left: 2rem;
-			padding-right: 0;
 		}
 	`];
 	}

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -123,6 +123,16 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 			margin-left: 0.5rem;
 			margin-right: 0;
 		}
+		.truncate {
+			overflow: hidden;
+			display: -webkit-box;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
+		}
+		:host[dir="rtl"] .truncate {
+			padding-left: 2rem;
+			padding-right: 0;
+		}
 	`];
 	}
 
@@ -318,7 +328,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 			@click="${
 	// eslint-disable-next-line lit/no-template-arrow
 	() => this._dispatchRenderEvidenceEvent(file.properties.fileViewer)}">
-				<span>${this._getFileTitle(file.properties.name)}</span>
+				<div class="truncate">${this._getFileTitle(file.properties.name)}</div>
 				<div slot="supporting-info">
 					${this._renderFlaggedStatus(file.properties.flagged)}
 					${this._getFileExtension(file.properties.name)}

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -134,6 +134,9 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 			-webkit-line-clamp: 3;
 			-webkit-box-orient: vertical;
 		}
+		.d2l-truncated-filename-tooltips {
+			overflow-wrap: break-word;
+		}
 	`];
 	}
 
@@ -318,7 +321,9 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	_renderAttachments() {
 		// href placeholder on list-item
 		return html`${this._attachments.map((file) => html`
-			<d2l-list-item @mouseover=${this.handle()}>
+			<d2l-list-item @mouseover=${
+	// eslint-disable-next-line lit/no-template-arrow
+	() => this.insertTooltipsAfterUpdateComplete()}>
 			<div slot="illustration" class="d2l-submission-attachment-icon-container">
 				<d2l-icon class="d2l-submission-attachment-icon-container-inner"
 					icon="tier2:${this._getIcon(file.properties.name)}"
@@ -415,17 +420,12 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		}
 	}
 
-	async _getUpdateComplete() {
-		await super._getUpdateComplete();
-		this.insertFilenameTooltips();
-	}
-
 	isClamped(e) {
 		return e.clientHeight < e.scrollHeight;
 	}
 
-	async handle() {
-		await Promise.all([this.updateComplete]);
+	async insertTooltipsAfterUpdateComplete() {
+		this.updateComplete.then(this.insertFilenameTooltips());
 	}
 
 	insertFilenameTooltips() {
@@ -435,7 +435,9 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 				const uniqueId = getUniqueId();
 				// attach to the d2l-list-item component for visibility
 				element.parentElement.parentElement.id = uniqueId;
-				element.parentElement.parentElement.insertAdjacentHTML('afterend', `<d2l-tooltip for="${uniqueId}" offset="0" align="start" style="overflow-wrap: break-word;">${element.innerText}</d2l-tooltip>`);
+				element.parentElement.parentElement.insertAdjacentHTML('afterend',
+					`<d2l-tooltip for="${uniqueId}" class="d2l-truncated-filename-tooltips"
+					offset="0" align="start">${element.innerText}</d2l-tooltip>`);
 			}
 		});
 	}

--- a/demo/data/submission2.json
+++ b/demo/data/submission2.json
@@ -23,7 +23,7 @@
             "https://assignments.api.brightspace.com/rels/attachment"
           ],
           "properties": {
-            "name": "Test doc.pdf",
+            "name": "qwertyuiop_asdfghjkl_zxcvbnm_12345678900987654321_qwertyuiop_asdfghjkl_zxcvbnm_12345678900987654321_12345678900987654321.pdf",
             "size": 124499,
             "flagged": true,
             "read": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-consistent-evaluation",
-  "version": "0.0.41",
+  "version": "0.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "d2l-rubric": "github:Brightspace/d2l-rubric#semver:^3",
     "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
     "lit-element": "^2",
-    "mobx": "^5.15.4"
+    "mobx": "^5.15.4",
+    "resize-observer-polyfill": "^1.5.1"
   }
 }


### PR DESCRIPTION
These changes should be able to take effect after this on core gets merged in: https://github.com/BrightspaceUI/core/pull/752
**Screenshot:**
![image](https://user-images.githubusercontent.com/12575962/89303887-c92f7800-d63a-11ea-9dff-57325d79fefd.png)
