### PR TITLE
Remove .skip from visualdiff tests

### DIFF
--- a/test/perceptual/consistent-evaluation-right-panel.visual-diff.js
+++ b/test/perceptual/consistent-evaluation-right-panel.visual-diff.js
@@ -48,7 +48,7 @@ describe('d2l-consistent-evaluation', () => {
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
-	it.skip('hiding-outcomes', async function() {
+	it('hiding-outcomes', async function() {
 		const rect = await visualDiff.getRect(page, '#hiding-outcomes');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});

--- a/test/perceptual/consistent-evaluation.visual-diff.js
+++ b/test/perceptual/consistent-evaluation.visual-diff.js
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 const VisualDiff = require('@brightspace-ui/visual-diff');
 
-describe.skip('d2l-consistent-evaluation', () => {
+describe('d2l-consistent-evaluation', () => {
 
 	const visualDiff = new VisualDiff('consistent-evaluation', __dirname);
 


### PR DESCRIPTION
Some tests were skipped and needed to be checked for the addition of StyleLint changes