### PR TITLE
Fix submission list appending when iterating through students

### DIFF
--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -42,7 +42,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 				type: String
 			},
 			attachments: {
-				type: Object
+				type: Array
 			},
 			comment: {
 				type: String
@@ -233,13 +233,13 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	}
 
 	_formatDateTime() {
-		this.dateStr = this.dateStr ? new Date(this.dateStr) : undefined;
+		const date = this.dateStr ? new Date(this.dateStr) : undefined;
 
-		const formattedDate = (this.dateStr) ? formatDate(
-			this.dateStr,
+		const formattedDate = (date) ? formatDate(
+			date,
 			{format: 'full'}) : '';
-		const formattedTime = (this.dateStr) ? formatTime(
-			this.dateStr,
+		const formattedTime = (date) ? formatTime(
+			date,
 			{format: 'short'}) : '';
 		return `${formattedDate} ${formattedTime}`;
 	}

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -13,7 +13,6 @@ import { bodySmallStyles, heading3Styles, labelStyles } from '@brightspace-ui/co
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { fileSubmission, textSubmission } from '../controllers/constants';
 import { formatDate, formatTime } from '@brightspace-ui/intl/lib/dateTime.js';
-import { Classes } from 'd2l-hypermedia-constants';
 import { getFileIconTypeFromExtension } from '@brightspace-ui/core/components/icons/getFileIconType';
 import { loadLocalizationResources } from '../locale.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
@@ -42,9 +41,11 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 			lateness: {
 				type: String
 			},
-			submissionEntity : {
-				attribute: false,
+			attachments: {
 				type: Object
+			},
+			comment: {
+				type: String
 			},
 			submissionType: {
 				attribute: 'submission-type',
@@ -138,24 +139,8 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	constructor() {
 		super();
 		this.late = false;
-		this._submissionEntity = undefined;
 		this._date = undefined;
-		this._attachments = [];
-		this._comment = '';
 		this._updateFilenameTooltips = this._updateFilenameTooltips.bind(this);
-	}
-
-	get submissionEntity() {
-		return this._submissionEntity;
-	}
-
-	set submissionEntity(newSubmission) {
-		const oldVal = this.submissionList;
-		if (oldVal !== newSubmission) {
-			this._submissionEntity = newSubmission;
-			this._initializeSubmissionProperties();
-			this.requestUpdate();
-		}
 	}
 
 	connectedCallback() {
@@ -178,18 +163,6 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		const filenames = this.shadowRoot.querySelectorAll('.d2l-truncate');
 		for (const filename of filenames) {
 			this._resizeObserver.observe(filename);
-		}
-	}
-
-	_initializeSubmissionProperties() {
-		this._comment = '';
-		this._date = this.dateStr ? new Date(this.dateStr) : undefined;
-		const attachmentsListEntity = this.submissionEntity.getSubEntityByClass(Classes.assignments.attachmentList);
-		if (attachmentsListEntity) {
-			this._attachments = attachmentsListEntity.getSubEntitiesByClass(Classes.assignments.attachment);
-		}
-		if (this.submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment)) {
-			this._comment = this.submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment).properties.html;
 		}
 	}
 
@@ -249,8 +222,8 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 				textSubmissionEvidence: {
 					title: `${this.localize('textSubmission')} ${this.displayNumber}`,
 					date: this._formatDateTime(),
-					downloadUrl: this._attachments[0].properties.href,
-					content: this._comment
+					downloadUrl: this.attachments[0].properties.href,
+					content: this.comment
 				}
 			},
 			composed: true
@@ -259,6 +232,8 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	}
 
 	_formatDateTime() {
+		this._date = this.dateStr ? new Date(this.dateStr) : undefined;
+
 		const formattedDate = (this._date) ? formatDate(
 			this._date,
 			{format: 'full'}) : '';
@@ -290,7 +265,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 
 	_renderTextSubmissionTitle() {
 		// There is only one attachment for text submissions: an html file
-		const file = this._attachments[0];
+		const file = this.attachments[0];
 		const flagged = file.properties.flagged;
 		const read = file.properties.read;
 		const href = file.properties.href;
@@ -351,7 +326,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	}
 
 	_renderAttachments() {
-		return html`${this._attachments.map((file) => {
+		return html`${this.attachments.map((file) => {
 			const {name, size, extension, flagged, read, href, fileViewer} = file.properties;
 			return html`
 			<d2l-list-item>
@@ -424,10 +399,10 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 
 	_renderComment() {
 		const peekHeight = this.submissionType === fileSubmission ? '5em' : '8em';
-		if (this._comment) {
+		if (this.comment) {
 			return html`
 					${this._renderCommentTitle()}
-					<d2l-more-less height=${peekHeight}>${unsafeHTML(this._comment)}</d2l-more-less>
+					<d2l-more-less height=${peekHeight}>${unsafeHTML(this.comment)}</d2l-more-less>
 				`;
 		}
 		return html``;

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -139,7 +139,8 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	constructor() {
 		super();
 		this.late = false;
-		this._date = undefined;
+		this.comment = '';
+		this.attachments = [];
 		this._updateFilenameTooltips = this._updateFilenameTooltips.bind(this);
 	}
 
@@ -232,13 +233,13 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	}
 
 	_formatDateTime() {
-		this._date = this.dateStr ? new Date(this.dateStr) : undefined;
+		this.dateStr = this.dateStr ? new Date(this.dateStr) : undefined;
 
-		const formattedDate = (this._date) ? formatDate(
-			this._date,
+		const formattedDate = (this.dateStr) ? formatDate(
+			this.dateStr,
 			{format: 'full'}) : '';
-		const formattedTime = (this._date) ? formatTime(
-			this._date,
+		const formattedTime = (this.dateStr) ? formatTime(
+			this.dateStr,
 			{format: 'short'}) : '';
 		return `${formattedDate} ${formattedTime}`;
 	}

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -182,6 +182,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 	}
 
 	_initializeSubmissionProperties() {
+		this._comment = '';
 		this._date = this.dateStr ? new Date(this.dateStr) : undefined;
 		const attachmentsListEntity = this.submissionEntity.getSubEntityByClass(Classes.assignments.attachmentList);
 		if (attachmentsListEntity) {

--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -18,6 +18,12 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 			},
 			token: {
 				type: String
+			},
+			_comment: {
+				type: String
+			},
+			_attachments: {
+				type: Object
 			}
 		};
 	}
@@ -94,6 +100,18 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 		return await window.D2L.Siren.EntityStore.fetch(submissionHref, this._token, false);
 	}
 
+	_initializeSubmissionProperties(submissionEntity) {
+		this._comment = '';
+		this._attachments = [];
+		const attachmentsListEntity = submissionEntity.getSubEntityByClass(Classes.assignments.attachmentList);
+		if (attachmentsListEntity) {
+			this._attachments = attachmentsListEntity.getSubEntitiesByClass(Classes.assignments.attachment);
+		}
+		if (submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment)) {
+			this._comment = submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment).properties.html;
+		}
+	}
+
 	_renderListItems() {
 		const itemTemplate = [];
 		for (let i = 0; i < this._submissionEntities.length; i++) {
@@ -103,6 +121,7 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 					const submissionDate = submissionEntity.getSubEntityByClass(Classes.assignments.submissionDate).properties.date;
 					const evaluationState = submissionEntity.properties.evaluationStatus;
 					const latenessTimespan = submissionEntity.properties.lateTimeSpan;
+					this._initializeSubmissionProperties(submissionEntity);
 					itemTemplate.push(html`
 						<d2l-consistent-evaluation-submission-item
 							date-str=${submissionDate}
@@ -110,7 +129,8 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 							evaluation-state=${evaluationState}
 							lateness=${moment.duration(Number(latenessTimespan), 'seconds').humanize()}
 							submission-type=${this.submissionType}
-							.submissionEntity=${submissionEntity}
+							comment=${this._comment}
+							.attachments=${this._attachments}
 							?late=${latenessTimespan !== undefined}
 						></d2l-consistent-evaluation-submission-item>`);
 				} else {

--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -79,6 +79,7 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 	}
 
 	async _initializeSubmissionEntities() {
+		this._submissionEntities = [];
 		if (this._submissionList !== undefined) {
 			for (const submissionLink of this._submissionList) {
 				if (submissionLink.href) {

--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -18,12 +18,6 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 			},
 			token: {
 				type: String
-			},
-			_comment: {
-				type: String
-			},
-			_attachments: {
-				type: Object
 			}
 		};
 	}
@@ -100,16 +94,19 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 		return await window.D2L.Siren.EntityStore.fetch(submissionHref, this._token, false);
 	}
 
-	_initializeSubmissionProperties(submissionEntity) {
-		this._comment = '';
-		this._attachments = [];
+	_getComment(submissionEntity) {
+		if (submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment)) {
+			return submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment).properties.html;
+		}
+		return '';
+	}
+
+	_getAttachments(submissionEntity) {
 		const attachmentsListEntity = submissionEntity.getSubEntityByClass(Classes.assignments.attachmentList);
 		if (attachmentsListEntity) {
-			this._attachments = attachmentsListEntity.getSubEntitiesByClass(Classes.assignments.attachment);
+			return attachmentsListEntity.getSubEntitiesByClass(Classes.assignments.attachment);
 		}
-		if (submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment)) {
-			this._comment = submissionEntity.getSubEntityByClass(Classes.assignments.submissionComment).properties.html;
-		}
+		return [];
 	}
 
 	_renderListItems() {
@@ -121,7 +118,6 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 					const submissionDate = submissionEntity.getSubEntityByClass(Classes.assignments.submissionDate).properties.date;
 					const evaluationState = submissionEntity.properties.evaluationStatus;
 					const latenessTimespan = submissionEntity.properties.lateTimeSpan;
-					this._initializeSubmissionProperties(submissionEntity);
 					itemTemplate.push(html`
 						<d2l-consistent-evaluation-submission-item
 							date-str=${submissionDate}
@@ -129,8 +125,8 @@ export class ConsistentEvaluationSubmissionsPage extends LitElement {
 							evaluation-state=${evaluationState}
 							lateness=${moment.duration(Number(latenessTimespan), 'seconds').humanize()}
 							submission-type=${this.submissionType}
-							comment=${this._comment}
-							.attachments=${this._attachments}
+							comment=${this._getComment(submissionEntity)}
+							.attachments=${this._getAttachments(submissionEntity)}
 							?late=${latenessTimespan !== undefined}
 						></d2l-consistent-evaluation-submission-item>`);
 				} else {


### PR DESCRIPTION
Related to [US120545](https://rally1.rallydev.com/#/294005552584d/custom/236803223728?detail=%2Fuserstory%2F435781871716)

Fixed issue where iterating through students, all evidence for the students would append onto the submissions list. Did this by clearing the list of submissions when initializing the submission entity.

Also fixed a bug where the comments would not update.

![submission-list-fix](https://user-images.githubusercontent.com/32204301/93784123-96e1d600-fbfa-11ea-9b67-e99d1eeb3060.gif)
