### PR TITLE
Jtran/nav bar responsiveness

### DIFF
--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -53,9 +53,6 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 				padding-top: 0.25rem;
 			}
 			.d2l-truncate {
-				-webkit-box-orient: vertical;
-				display: -webkit-box;
-				-webkit-line-clamp: 1;
 				overflow: hidden;
 				overflow-wrap: break-word;
 				text-overflow: ellipsis;

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -145,11 +145,11 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 					hide-text>
 
 					<div class="d2l-iterator-space"> 
-						<span class="d2l-iterator-text d2l-label-text">${this.localize('user')} ${this.iteratorIndex} ${this.localize('of')} ${this.iteratorTotal}</span>
+						<span class="d2l-iterator-text d2l-label-text">${this.localize('iteratorText', { num: this.iteratorIndex, total: this.iteratorTotal }) }</span>
 					</div>
 
 				</d2l-navigation-iterator>
-
+				
 			</d2l-navigation-immersive>
 		`;
 	}

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -118,8 +118,7 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 
 				<d2l-navigation-link-back 
 					class="d2l-short-back"
-					href=${this.returnHref}
-					text="Back">
+					href=${this.returnHref}>
 				</d2l-navigation-link-back>
 			`;
 		}

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -1,6 +1,8 @@
+
 import 'd2l-navigation/d2l-navigation-immersive.js';
 import 'd2l-navigation/components/d2l-navigation-iterator/d2l-navigation-iterator.js';
 import 'd2l-navigation/d2l-navigation-link-back.js';
+import '@brightspace-ui/core/components/tooltip/tooltip.js';
 
 import { css, html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
@@ -47,6 +49,15 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 			.d2l-heading-3 {
 				padding-top: 0.25rem;
 			}
+			.d2l-truncate {
+				-webkit-box-orient: vertical;
+				display: -webkit-box;
+				-webkit-line-clamp: 1;
+				overflow: hidden;
+				overflow-wrap: break-word;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 		`];
 	}
 
@@ -90,8 +101,12 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 				</div>
 
 				<div slot="middle">
-					<div class="d2l-heading-3">${this.assignmentName}</div>
-					<div class="d2l-label-text">${this.organizationName}</div>
+					<div id="assignmentName" class="d2l-heading-3 d2l-truncate">${this.assignmentName}</div>
+					<d2l-tooltip for="assignmentName">${this.assignmentName}</d2l-tooltip>
+
+					<div id="className" class="d2l-label-text d2l-truncate">{this.organizationName}</div>
+					<d2l-tooltip for="className">{this.organizationName}</d2l-tooltip>
+
 				</div>
 
 				<d2l-navigation-iterator 

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -42,7 +42,10 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 
 	static get styles() {
 		return [labelStyles, css`
-			.d2l-student-iterator {
+			.d2l-short-back {
+				display: none;
+			}
+			.d2l-iterator-text {
 				padding-left: 4rem;
 				padding-right: 4rem;
 			}
@@ -58,6 +61,30 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
+
+			@media (max-width: 929px) {
+				.d2l-iterator-text {
+					padding-left: 1rem;
+					padding-right: 1rem;
+				}
+			}
+
+			@media (max-width: 556px) {
+				.d2l-iterator-text {
+					display: none;
+				}
+				.d2l-iterator-space {
+					padding-left: 0.5rem;
+					padding-right: 0.5rem;
+				}
+				.d2l-short-back {
+					display: inline-block;
+				}
+				.d2l-full-back {
+					display: none;
+				}
+			}
+
 		`];
 	}
 
@@ -84,8 +111,15 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 
 			return html`
 				<d2l-navigation-link-back 
+					class="d2l-full-back"
 					href=${this.returnHref}
 					text=${ifDefined(this.returnHrefText)} >
+				</d2l-navigation-link-back>
+
+				<d2l-navigation-link-back 
+					class="d2l-short-back"
+					href=${this.returnHref}
+					text="Back">
 				</d2l-navigation-link-back>
 			`;
 		}
@@ -102,11 +136,9 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 
 				<div slot="middle">
 					<div id="assignmentName" class="d2l-heading-3 d2l-truncate">${this.assignmentName}</div>
-					<d2l-tooltip for="assignmentName">${this.assignmentName}</d2l-tooltip>
-
-					<div id="className" class="d2l-label-text d2l-truncate">{this.organizationName}</div>
-					<d2l-tooltip for="className">{this.organizationName}</d2l-tooltip>
-
+					<div id="className" class="d2l-label-text d2l-truncate">${this.organizationName}</div>
+					<d2l-tooltip for="assignmentName"> ${this.assignmentName}</d2l-tooltip>
+					<d2l-tooltip for="className">${this.organizationName}</d2l-tooltip>
 				</div>
 
 				<d2l-navigation-iterator 
@@ -116,7 +148,10 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 					?previous-disabled=${(this.iteratorIndex === 1 || this.iteratorIndex === undefined)}
 					?next-disabled=${(this.iteratorIndex === this.iteratorTotal || this.iteratorIndex === undefined || this.iteratorIndex === undefined)}
 					hide-text>
-					<span class="d2l-student-iterator d2l-label-text">${this.localize('user')} ${this.iteratorIndex} ${this.localize('of')} ${this.iteratorTotal}</span>
+
+					<div class="d2l-iterator-space"> </div>
+					<span class="d2l-iterator-text d2l-label-text">${this.localize('user')} ${this.iteratorIndex} ${this.localize('of')} ${this.iteratorTotal}</span>
+
 				</d2l-navigation-iterator>
 
 			</d2l-navigation-immersive>

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -71,8 +71,7 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 					display: none;
 				}
 				.d2l-iterator-space {
-					padding-left: 0.5rem;
-					padding-right: 0.5rem;
+					min-width: 1rem;
 				}
 				.d2l-short-back {
 					display: inline-block;
@@ -145,8 +144,9 @@ class ConsistentEvaluationNavBar extends LocalizeMixin(LitElement) {
 					?next-disabled=${(this.iteratorIndex === this.iteratorTotal || this.iteratorIndex === undefined || this.iteratorIndex === undefined)}
 					hide-text>
 
-					<div class="d2l-iterator-space"> </div>
-					<span class="d2l-iterator-text d2l-label-text">${this.localize('user')} ${this.iteratorIndex} ${this.localize('of')} ${this.iteratorTotal}</span>
+					<div class="d2l-iterator-space"> 
+						<span class="d2l-iterator-text d2l-label-text">${this.localize('user')} ${this.iteratorIndex} ${this.localize('of')} ${this.iteratorTotal}</span>
+					</div>
 
 				</d2l-navigation-iterator>
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -47,6 +47,5 @@ export const val = {
 	retracted:   'Evaluation retracted',
 	saved:  'Evaluation saved as draft',
 	updated:  'Evaluation updated',
-	user: 'User',
-	of: 'of'
+	iteratorText: 'User {num} of {total}',
 };


### PR DESCRIPTION
Related to [US120544](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F435780339580)

Added truncation and tool-tips of course & assignment names
Added responsive-ness to the back button and iterator component

Note: we want the tool-tip to only show on truncation (Milestone 2)

![nav-bar-responsiveness](https://user-images.githubusercontent.com/32204301/94306113-6672a280-ff40-11ea-88d3-09b4396e26f8.gif)

