### PR TITLE
Do not use cache when loading entity in consistent-evaluation-page

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -253,7 +253,8 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 
 	async _initializeController() {
 		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._token);
-		this.evaluationEntity = await this._controller.fetchEvaluationEntity();
+		const bypassCache = true;
+		this.evaluationEntity = await this._controller.fetchEvaluationEntity(bypassCache);
 		this.evaluationState = this.evaluationEntity.properties.state;
 		this.allowEvaluationWrite = this._controller.userHasWritePermission(this.evaluationEntity);
 		this.allowEvaluationDelete = this._controller.userHasDeletePermission(this.evaluationEntity);


### PR DESCRIPTION
Problem: when iterating between students, transiently saved state (such as text feedback) should not be persisted. To reproduce:

1. change text feedback from `"good"` to `"not good"`
2. iterate to next student
3. iterate back to previous student

expected: feedback is `"good"`
actual: feedback is `"not good"`

Solution: What's going on here is EntityStore is caching our transiently saved state (the `"not good"`). So when we hit that cache we're getting the "dirty" value. So we simply bypass the cache and go straight to the API when loading `consistent-evaluation-page`. The tradeoff for this correctness is performance, now we must load fresh each time we iterate (previously if we iterated backwards to something we'd already seen, it would just load what it had from cache).