### PR TITLE
- Fixing submission info console error

### DIFF
--- a/components/left-panel/consistent-evaluation-left-panel.js
+++ b/components/left-panel/consistent-evaluation-left-panel.js
@@ -151,11 +151,11 @@ export class ConsistentEvaluationLeftPanel extends LocalizeMixin(LitElement) {
 			if (submissionTypesWithNoEvidence.includes(this.submissionInfo.submissionType)) {
 				return this._renderNoEvidenceSubmissionType();
 			}
-	
+
 			if (this.submissionInfo.submissionList === undefined) {
 				return this._renderNoSubmissions();
 			}
-		}		
+		}
 
 		if (this.fileEvidenceUrl) {
 			return this._renderFileEvidence();

--- a/components/left-panel/consistent-evaluation-left-panel.js
+++ b/components/left-panel/consistent-evaluation-left-panel.js
@@ -147,13 +147,15 @@ export class ConsistentEvaluationLeftPanel extends LocalizeMixin(LitElement) {
 			return this._renderOverallAchievement();
 		}
 
-		if (submissionTypesWithNoEvidence.includes(this.submissionInfo.submissionType)) {
-			return this._renderNoEvidenceSubmissionType();
-		}
-
-		if (this.submissionInfo.submissionList === undefined) {
-			return this._renderNoSubmissions();
-		}
+		if (this.submissionInfo) {
+			if (submissionTypesWithNoEvidence.includes(this.submissionInfo.submissionType)) {
+				return this._renderNoEvidenceSubmissionType();
+			}
+	
+			if (this.submissionInfo.submissionList === undefined) {
+				return this._renderNoSubmissions();
+			}
+		}		
 
 		if (this.fileEvidenceUrl) {
 			return this._renderFileEvidence();


### PR DESCRIPTION
It was really just a timing problem, the error would resolve on the 2nd draw once the submission list object is defined, but will remove the original error from the console now