### PR TITLE
lock node version in travis (for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-node_js: node
+node_js:
+ - 14
 addons:
   chrome: stable
 


### PR DESCRIPTION
15.0.0 is causing npm ci issues