### PR TITLE
DE41070 - Show COA achievements selector on right panel

### DIFF
--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -1,5 +1,5 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { actorRel, alignmentsRel, assessmentRel, checkpointItemType, demonstrationRel, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeRel, userRel } from './constants.js';
+import { actorRel, alignmentsRel, assessmentRel, demonstrationRel, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeRel, userRel } from './constants.js';
 import { Classes, Rels } from 'd2l-hypermedia-constants';
 
 export const ConsistentEvaluationHrefControllerErrors = {
@@ -64,9 +64,7 @@ export class ConsistentEvaluationHrefController {
 			alignmentsHref = this._getHref(root, alignmentsRel);
 			groupHref = this._getHref(root, groupRel);
 
-			if (root.hasClass(checkpointItemType)) {
-				userProgressOutcomeHref = this._getHref(root, userProgressOutcomeRel);
-			}
+			userProgressOutcomeHref = this._getHref(root, userProgressOutcomeRel);
 
 			if (rubricAssessmentHref) {
 				const assessmentEntity = await this._getEntityFromHref(rubricAssessmentHref, bypassCache);
@@ -78,7 +76,7 @@ export class ConsistentEvaluationHrefController {
 			if (alignmentsHref) {
 				const alignmentsEntity = await this._getEntityFromHref(alignmentsHref, bypassCache);
 				if (alignmentsEntity && alignmentsEntity.entity) {
-					if (root.hasClass(checkpointItemType)) {
+					if (userProgressOutcomeHref) {
 						alignmentsHref = undefined;
 						const referencedAlignmentEntity = alignmentsEntity.entity.getSubEntityByRel('item');
 						if (referencedAlignmentEntity) {

--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -82,7 +82,10 @@ export class ConsistentEvaluationHrefController {
 						if (referencedAlignmentEntity) {
 							const alignmentEntity = await this._getEntityFromHref(referencedAlignmentEntity.href, bypassCache);
 							if (alignmentEntity && alignmentEntity.entity) {
-								coaDemonstrationHref = alignmentEntity.entity.getLinkByRel(demonstrationRel)?.href;
+								const demonstrationLink = alignmentEntity.entity.getLinkByRel(demonstrationRel);
+								if (demonstrationLink) {
+									coaDemonstrationHref = demonstrationLink.href;
+								}
 							}
 						}
 					} else {

--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -1,5 +1,5 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { actorRel, alignmentsRel, assessmentRel, checkpointItemType, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeActivitiesRel, userProgressOutcomeRel, userRel} from './constants.js';
+import { actorRel, alignmentsRel, assessmentRel, checkpointItemType, demonstrationRel, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeActivitiesRel, userProgressOutcomeRel, userRel } from './constants.js';
 import { Classes, Rels } from 'd2l-hypermedia-constants';
 
 export const ConsistentEvaluationHrefControllerErrors = {
@@ -75,10 +75,21 @@ export class ConsistentEvaluationHrefController {
 			if (alignmentsHref) {
 				const alignmentsEntity = await this._getEntityFromHref(alignmentsHref, bypassCache);
 				if (alignmentsEntity && alignmentsEntity.entity) {
-					if (alignmentsEntity.entity.entities && alignmentsEntity.entity.entities.length > 0) {
-						alignmentsHref = actorHref;
-					} else {
+					if (userProgressOutcomeHref) {
 						alignmentsHref = undefined;
+						const referencedAlignmentEntity = alignmentsEntity.entity.getSubEntityByRel("item");
+						if (referencedAlignmentEntity) {
+							const alignmentEntity = await this._getEntityFromHref(referencedAlignmentEntity.href, bypassCache);
+							if (alignmentEntity && alignmentEntity.entity) {
+								coaDemonstrationHref = alignmentEntity.entity.getLinkByRel(demonstrationRel)?.href;
+							}
+						}
+					} else {
+						if (alignmentsEntity.entity.entities && alignmentsEntity.entity.entities.length > 0) {
+							alignmentsHref = actorHref;
+						} else {
+							alignmentsHref = undefined;
+						}
 					}
 				}
 			}
@@ -175,9 +186,9 @@ export class ConsistentEvaluationHrefController {
 					const gradeLink = activityUsageResponse.entity.getLinkByRel(Rels.Grades.grade).href;
 					const gradeResponse = await this._getEntityFromHref(gradeLink, false);
 
-					if (gradeResponse && gradeResponse.entity  && gradeResponse.entity.properties) {
+					if (gradeResponse && gradeResponse.entity && gradeResponse.entity.properties) {
 						evaluationUrl = gradeResponse.entity.properties.evaluationUrl;
-						statsUrl  = gradeResponse.entity.properties.statsUrl;
+						statsUrl = gradeResponse.entity.properties.statsUrl;
 						gradeItemName = gradeResponse.entity.properties.name;
 					}
 				}

--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -1,5 +1,5 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { actorRel, alignmentsRel, assessmentRel, checkpointItemType, demonstrationRel, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeActivitiesRel, userProgressOutcomeRel, userRel } from './constants.js';
+import { actorRel, alignmentsRel, assessmentRel, checkpointItemType, demonstrationRel, editSpecialAccessApplicationRel, evaluationRel, groupRel, nextRel, previousRel, rubricRel, userProgressOutcomeRel, userRel } from './constants.js';
 import { Classes, Rels } from 'd2l-hypermedia-constants';
 
 export const ConsistentEvaluationHrefControllerErrors = {
@@ -62,8 +62,11 @@ export class ConsistentEvaluationHrefController {
 			actorHref = this._getHref(root, actorRel);
 			userHref = this._getHref(root, userRel);
 			alignmentsHref = this._getHref(root, alignmentsRel);
-			userProgressOutcomeHref = this._getHref(root, userProgressOutcomeRel);
 			groupHref = this._getHref(root, groupRel);
+
+			if (root.hasClass(checkpointItemType)) {
+				userProgressOutcomeHref = this._getHref(root, userProgressOutcomeRel);
+			}
 
 			if (rubricAssessmentHref) {
 				const assessmentEntity = await this._getEntityFromHref(rubricAssessmentHref, bypassCache);
@@ -75,9 +78,9 @@ export class ConsistentEvaluationHrefController {
 			if (alignmentsHref) {
 				const alignmentsEntity = await this._getEntityFromHref(alignmentsHref, bypassCache);
 				if (alignmentsEntity && alignmentsEntity.entity) {
-					if (userProgressOutcomeHref) {
+					if (root.hasClass(checkpointItemType)) {
 						alignmentsHref = undefined;
-						const referencedAlignmentEntity = alignmentsEntity.entity.getSubEntityByRel("item");
+						const referencedAlignmentEntity = alignmentsEntity.entity.getSubEntityByRel('item');
 						if (referencedAlignmentEntity) {
 							const alignmentEntity = await this._getEntityFromHref(referencedAlignmentEntity.href, bypassCache);
 							if (alignmentEntity && alignmentEntity.entity) {
@@ -89,30 +92,6 @@ export class ConsistentEvaluationHrefController {
 							alignmentsHref = actorHref;
 						} else {
 							alignmentsHref = undefined;
-						}
-					}
-				}
-			}
-
-			if (userProgressOutcomeHref) {
-				const userProgressOutcomeEntity = await this._getEntityFromHref(userProgressOutcomeHref, bypassCache);
-				if (userProgressOutcomeEntity && userProgressOutcomeEntity.entity) {
-					const userProgressOutcomeActivitiesHref = this._getHref(userProgressOutcomeEntity.entity, userProgressOutcomeActivitiesRel);
-
-					if (userProgressOutcomeActivitiesHref) {
-						const userProgressOutcomeActivitiesEntity = await this._getEntityFromHref(userProgressOutcomeActivitiesHref, bypassCache);
-
-						if (userProgressOutcomeActivitiesEntity && userProgressOutcomeActivitiesEntity.entity) {
-							const checkpointActivityEntity = userProgressOutcomeActivitiesEntity.entity.getSubEntitiesByClass(Classes.userProgress.outcomes.activity).find((activityEntity) => {
-								return activityEntity.properties && activityEntity.properties.type === checkpointItemType;
-							});
-
-							if (checkpointActivityEntity) {
-								const demonstrationEntity = checkpointActivityEntity.getSubEntityByClass(Classes.outcomes.demonstration);
-								if (demonstrationEntity) {
-									coaDemonstrationHref = this._getHref(demonstrationEntity, 'self');
-								}
-							}
 						}
 					}
 				}

--- a/components/controllers/constants.js
+++ b/components/controllers/constants.js
@@ -20,6 +20,7 @@ export const attachmentListRel = 'https://assignments.api.brightspace.com/rels/a
 export const editSpecialAccessApplicationRel = 'https://assignments.api.brightspace.com/rels/edit-special-access-application';
 export const userProgressOutcomeRel = 'user-progress-outcome';
 export const userProgressOutcomeActivitiesRel = 'https://user-progress.api.brightspace.com/rels/outcome-activities';
+export const demonstrationRel = 'https://achievements.api.brightspace.com/rels/demonstration';
 export const nextRel = 'next';
 export const previousRel = 'previous';
 export const itemRel = 'item';


### PR DESCRIPTION
The COA achievements selector does not show up if there is no initial evaluated checkpoint demonstration. We can instead get the demonstration from the linked Alignments entity.
https://rally1.rallydev.com/#/detail/defect/449083112472?fdp=true
