### PR TITLE
Abedley/annotations/file id refactor

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -17,7 +17,6 @@ import { ConsistentEvaluationController } from './controllers/ConsistentEvaluati
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { loadLocalizationResources } from './locale.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { submissions } from './controllers/constants';
 
 const DIALOG_ACTION_LEAVE = 'leave';
 
@@ -144,18 +143,6 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 			},
 			_scrollbarStatus: {
 				attribute: false
-			},
-			_fileEvidenceUrl: {
-				attribute: false,
-				type: String
-			},
-			_textEvidence: {
-				attribute: false,
-				type: Object
-			},
-			_selectedFile: {
-				attribute: false,
-				type: String
 			},
 			_dialogOpened: {
 				attribute: false
@@ -325,13 +312,6 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 			composed: true,
 			bubbles: true
 		}));
-	}
-
-	_resetEvidence() {
-		this._selectedFile = submissions;
-		this.submissionInfo = undefined;
-		this._fileEvidenceUrl = undefined;
-		this._textEvidence = undefined;
 	}
 
 	_hideScrollbars() {
@@ -527,7 +507,6 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 				<d2l-consistent-evaluation-learner-context-bar
 					user-href=${ifDefined(this.userHref)}
 					group-href=${ifDefined(this.groupHref)}
-					selected-item-name=${this._selectedFile}
 					special-access-href=${ifDefined(this.specialAccessHref)}
 					.token=${this.token}
 					.currentFileId=${this.currentFileId}
@@ -537,29 +516,18 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 		}
 	}
 
+	_selectFile(e) {
+		this.currentFileId = e.detail.fileId;
+		this._hideScrollbars();
+	}
+
 	_setSubmissionsView() {
 		this.currentFileId = undefined;
-	}
-	_setFileEvidence(e) {
-		this._fileEvidenceUrl = e.detail.url;
-		this._selectedFile = e.detail.name;
-		this._textEvidence = undefined;
-		this._hideScrollbars();
-	}
-	_setTextEvidence(e) {
-		this._textEvidence = e.detail.textSubmissionEvidence;
-		this._selectedFile = e.detail.textSubmissionEvidence.name;
-		this._fileEvidenceUrl = undefined;
-		this._hideScrollbars();
+		this._showScrollbars();
 	}
 
 	async _handleAnnotationsUpdate() {
 
-	}
-
-	_selectFile(e) {
-		console.log(e);
-		this.currentFileId = e.detail.fileId;
 	}
 
 	connectedCallback() {
@@ -595,8 +563,6 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 					<d2l-consistent-evaluation-left-panel
 						.submissionInfo=${this.submissionInfo}
 						.token=${this.token}
-						file-evidence-url=${ifDefined(this._fileEvidenceUrl)}
-						.textEvidence=${this._textEvidence}
 						user-progress-outcome-href=${ifDefined(this.userProgressOutcomeHref)}
 						.currentFileId=${this.currentFileId}
 						@d2l-consistent-eval-annotations-update=${this._handleAnnotationsUpdate}

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -530,7 +530,7 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 					selected-item-name=${this._selectedFile}
 					special-access-href=${ifDefined(this.specialAccessHref)}
 					.token=${this.token}
-					current-file-id=${this.currentFileId}
+					.currentFileId=${this.currentFileId}
 					.submissionInfo=${this.submissionInfo}
 				></d2l-consistent-evaluation-learner-context-bar>
 			`;

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -112,7 +112,7 @@ export class ConsistentEvaluation extends MobxLitElement {
 				special-access-href=${ifDefined(this._childHrefs && this._childHrefs.specialAccessHref)}
 				return-href=${ifDefined(this.returnHref)}
 				return-href-text=${ifDefined(this.returnHrefText)}
-				current-file-id=${ifDefined(this.fileId !== null && this.fileId)}
+				current-file-id=${ifDefined(this.fileId)}
 				.submissionInfo=${this._submissionInfo}
 				.gradeItemInfo=${this._gradeItemInfo}
 				.assignmentName=${this._assignmentName}

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -72,7 +72,7 @@ export class ConsistentEvaluation extends MobxLitElement {
 			this._userName = await controller.getUserName();
 			this._iteratorTotal = await controller.getIteratorInfo('total');
 			this._iteratorIndex = await controller.getIteratorInfo('index');
-			this.shadowRoot.querySelector('d2l-consistent-evaluation-page')._resetEvidence();
+			this.shadowRoot.querySelector('d2l-consistent-evaluation-page')._setSubmissionsView();
 			this._stripFileIdFromUrl();
 		}
 	}

--- a/components/header/d2l-consistent-evaluation-lcb-file-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-file-context.js
@@ -178,7 +178,7 @@ export class ConsistentEvaluationLcbFileContext extends RtlMixin(LocalizeMixin(L
 				<option label=${this.localize('userSubmissions')} value=${submissions} ?selected=${!this.currentFileId}></option>
 				${this._files.map(submission => html`
 					<optgroup label=${this.localize('submissionNumber', 'number', submission.submissionNumber)}>
-						${getSubmissionFiles(submission, this.token).map(sf => html`
+						${getSubmissionFiles(submission).map(sf => html`
 							<option value=${sf.id} label=${this._truncateFileName(sf.name)} ?selected=${sf.id === this.currentFileId} class="select-option"></option>
 						`)}
 					</optgroup>

--- a/components/header/d2l-consistent-evaluation-lcb-file-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-file-context.js
@@ -36,6 +36,10 @@ export class ConsistentEvaluationLcbFileContext extends RtlMixin(LocalizeMixin(L
 			_showFiles: {
 				attribute: false,
 				type: Boolean
+			},
+			currentFileId: {
+				attribute: 'current-file-id',
+				type: String
 			}
 		};
 	}
@@ -99,13 +103,24 @@ export class ConsistentEvaluationLcbFileContext extends RtlMixin(LocalizeMixin(L
 		}
 
 		const submission = JSON.parse(e.target.value);
-		if (submission.comment === undefined) {
+		/*if (submission.comment === undefined) {
 			this._dispatchRenderEvidenceFileEvent(submission);
 		} else {
 			this._dispatchRenderEvidenceTextEvent(submission);
-		}
+		}*/
+		this._dispatchFileSelectedEvent(submission.id);
 
 		this._submissionLateness = submission.latenessTimespan;
+	}
+
+	_dispatchFileSelectedEvent(fileId) {
+		this.dispatchEvent(new CustomEvent('d2l-consistent-evaluation-file-selected', {
+			detail: {
+				fileId: fileId
+			},
+			composed: true,
+			bubbles: true
+		}));
 	}
 
 	_dispatchRenderEvidenceFileEvent(sf) {
@@ -206,10 +221,10 @@ export class ConsistentEvaluationLcbFileContext extends RtlMixin(LocalizeMixin(L
 		return html`
 			<select class="d2l-input-select d2l-truncate" aria-label=${this.localize('userSubmissions')} @change=${this._onSelectChange}>
 				<option label=${this.localize('userSubmissions')} value=${submissions} ?selected=${this.selectedItemName === submissions}></option>
-				${this._files && this._files.map(submission => html`
+				${this._files.map(submission => html`
 					<optgroup label=${this.localize('submissionNumber', 'number', submission.submissionNumber)}>
 						${getSubmissionFiles(submission, this.token).map(sf => html`
-							<option value=${JSON.stringify(sf)} label=${this._truncateFileName(sf.name)} ?selected=${sf.name === this.selectedItemName} class="select-option"></option>
+							<option value=${JSON.stringify(sf)} label=${this._truncateFileName(sf.name)} ?selected=${sf.id === this.currentFileId} class="select-option"></option>
 						`)}
 					</optgroup>
 				`)};

--- a/components/header/d2l-consistent-evaluation-learner-context-bar.js
+++ b/components/header/d2l-consistent-evaluation-learner-context-bar.js
@@ -27,10 +27,6 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 				attribute: false,
 				type: Object
 			},
-			selectedItemName: {
-				attribute: 'selected-item-name',
-				type: String
-			},
 			currentFileId: {
 				type: String
 			}
@@ -90,6 +86,7 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 				?is-group-activity="${this.groupHref}"
 			></d2l-consistent-evaluation-lcb-user-context>
 			<d2l-consistent-evaluation-lcb-file-context
+				.token="${this.token}"
 				special-access-href=${this.specialAccessHref}
 				.currentFileId=${this.currentFileId}
 				.submissionInfo="${this.submissionInfo}">

--- a/components/header/d2l-consistent-evaluation-learner-context-bar.js
+++ b/components/header/d2l-consistent-evaluation-learner-context-bar.js
@@ -30,6 +30,10 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 			selectedItemName: {
 				attribute: 'selected-item-name',
 				type: String
+			},
+			currentFileId: {
+				attribute: 'current-file-id',
+				type: String
 			}
 		};
 	}
@@ -71,11 +75,7 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 	}
 
 	_getIsExempt() {
-		if (this.submissionInfo && this.submissionInfo.isExempt) {
-			return true;
-		} else {
-			return false;
-		}
+		return this.submissionInfo && this.submissionInfo.isExempt;
 	}
 
 	_getActorHref() {
@@ -93,6 +93,7 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 			<d2l-consistent-evaluation-lcb-file-context
 				selected-item-name=${this.selectedItemName}
 				special-access-href=${this.specialAccessHref}
+				current-file-id=${this.currentFileId}
 				.submissionInfo="${this.submissionInfo}">
 			</d2l-consistent-evaluation-lcb-file-context>
 		`;

--- a/components/header/d2l-consistent-evaluation-learner-context-bar.js
+++ b/components/header/d2l-consistent-evaluation-learner-context-bar.js
@@ -32,7 +32,6 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 				type: String
 			},
 			currentFileId: {
-				attribute: 'current-file-id',
 				type: String
 			}
 		};
@@ -91,9 +90,8 @@ export class ConsistentEvaluationLearnerContextBar extends RtlMixin(LitElement) 
 				?is-group-activity="${this.groupHref}"
 			></d2l-consistent-evaluation-lcb-user-context>
 			<d2l-consistent-evaluation-lcb-file-context
-				selected-item-name=${this.selectedItemName}
 				special-access-href=${this.specialAccessHref}
-				current-file-id=${this.currentFileId}
+				.currentFileId=${this.currentFileId}
 				.submissionInfo="${this.submissionInfo}">
 			</d2l-consistent-evaluation-lcb-file-context>
 		`;

--- a/components/helpers/submissionsAndFilesHelpers.js
+++ b/components/helpers/submissionsAndFilesHelpers.js
@@ -2,6 +2,20 @@ import 'd2l-polymer-siren-behaviors/store/entity-store.js';
 import { attachmentListRel } from '../controllers/constants';
 import { Classes } from 'd2l-hypermedia-constants';
 
+export function findFile(fileId, submissions) {
+	for (let i = 0; i < submissions.length; i++) {
+		const submission = submissions[i];
+		const files = getSubmissionFiles(submission);
+		for (let j = 0; j < files.length; j++) {
+			const submissionFile = files[j];
+			if (submissionFile.id === fileId) {
+				return submissionFile;
+			}
+		}
+	}
+
+}
+
 export function getSubmissionFiles(submission) {
 	const attachments = submission.entity.getSubEntityByRel(attachmentListRel);
 	return attachments.entities.map(sf => {
@@ -30,4 +44,3 @@ export async function getSubmissions(submissionInfo, token) {
 		return Promise.all(submissionEntities);
 	}
 }
-

--- a/components/left-panel/consistent-evaluation-left-panel.js
+++ b/components/left-panel/consistent-evaluation-left-panel.js
@@ -5,7 +5,7 @@ import './consistent-evaluation-outcomes-overall-achievement.js';
 import { bodyStandardStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element';
 import { fileSubmission, observedInPerson, onPaperSubmission, submissionTypesWithNoEvidence, textSubmission } from '../controllers/constants';
-import { getSubmissionFiles, getSubmissions } from '../helpers/submissionsAndFilesHelpers.js';
+import { findFile, getSubmissions } from '../helpers/submissionsAndFilesHelpers.js';
 import { loadLocalizationResources } from '../locale.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 
@@ -112,23 +112,9 @@ export class ConsistentEvaluationLeftPanel extends LocalizeMixin(LitElement) {
 
 	}
 
-	findFile(fileId, submissions) {
-		for (let i = 0; i < submissions.length; i++) {
-			const submission = submissions[i];
-			const files = getSubmissionFiles(submission);
-			for (let j = 0; j < files.length; j++) {
-				const submissionFile = files[j];
-				if (submissionFile.id === fileId) {
-					return submissionFile;
-				}
-			}
-		}
-
-	}
-
 	async getFileFromId() {
 		const submissions = await getSubmissions(this.submissionInfo, this.token);
-		const currentFile = this.findFile(this.currentFileId, submissions);
+		const currentFile = findFile(this.currentFileId, submissions);
 
 		if (!currentFile) {
 			console.error(`Cannot find fileId ${this.currentFileId}`);

--- a/components/left-panel/consistent-evaluation-left-panel.js
+++ b/components/left-panel/consistent-evaluation-left-panel.js
@@ -98,7 +98,7 @@ export class ConsistentEvaluationLeftPanel extends LocalizeMixin(LitElement) {
 
 	async updated(changedProperties) {
 		super.updated();
-		console.log(this.currentFileId);
+
 		if ((changedProperties.has('currentFileId') || changedProperties.has('token') || changedProperties.has('submissionInfo'))
 			&& this.currentFileId
 			&& this.token
@@ -129,6 +129,11 @@ export class ConsistentEvaluationLeftPanel extends LocalizeMixin(LitElement) {
 	async getFileFromId() {
 		const submissions = await getSubmissions(this.submissionInfo, this.token);
 		const currentFile = this.findFile(this.currentFileId, submissions);
+
+		if (!currentFile) {
+			console.error(`Cannot find fileId ${this.currentFileId}`);
+			return;
+		}
 
 		if (this.submissionInfo.submissionType === fileSubmission) {
 			this.fileEvidenceUrl = currentFile.fileViewer;

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -145,6 +145,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		this.attachments = [];
 		this._updateFilenameTooltips = this._updateFilenameTooltips.bind(this);
 		this._dispatchRenderEvidence = this._dispatchRenderEvidence.bind(this);
+		//this._dispatchFileSelectedEvent = this._dispatchFileSelectedEvent.bind(this);
 	}
 
 	connectedCallback() {
@@ -199,6 +200,16 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		} while (fileSizeBytes > 1024);
 		const unit = this.localize(byteUnits[i]);
 		return Math.max(fileSizeBytes, 0.1).toFixed(1) + unit;
+	}
+
+	_dispatchFileSelectedEvent(fileId) {
+		this.dispatchEvent(new CustomEvent('d2l-consistent-evaluation-file-selected', {
+			detail: {
+				fileId: fileId
+			},
+			composed: true,
+			bubbles: true
+		}));
 	}
 
 	_dispatchRenderEvidence(extension, fileViewer, name) {
@@ -344,7 +355,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 
 	_renderAttachments() {
 		return html`${this.attachments.map((file) => {
-			const {id, name, size, extension, flagged, read, href, fileViewer} = file.properties;
+			const {id, name, size, extension, flagged, read, href} = file.properties;
 			return html`
 			<d2l-list-item>
 				<div slot="illustration" class="d2l-submission-attachment-icon-container">
@@ -356,7 +367,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 				<d2l-list-item-content
 				@click="${
 	// eslint-disable-next-line lit/no-template-arrow
-	() => this._dispatchRenderEvidence(extension, fileViewer, name)}">
+	() => this._dispatchFileSelectedEvent(id)}">
 					<div class="truncate" aria-label="heading">${this._getFileTitle(name)}</div>
 					<div slot="supporting-info">
 						${this._renderFlaggedStatus(flagged)}

--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -144,8 +144,6 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		this.comment = '';
 		this.attachments = [];
 		this._updateFilenameTooltips = this._updateFilenameTooltips.bind(this);
-		this._dispatchRenderEvidence = this._dispatchRenderEvidence.bind(this);
-		//this._dispatchFileSelectedEvent = this._dispatchFileSelectedEvent.bind(this);
 	}
 
 	connectedCallback() {
@@ -212,39 +210,6 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		}));
 	}
 
-	_dispatchRenderEvidence(extension, fileViewer, name) {
-		this._dispatchRenderEvidenceFileEvent(fileViewer, name);
-	}
-
-	_dispatchRenderEvidenceFileEvent(url, name) {
-		const event = new CustomEvent('d2l-consistent-evaluation-submission-item-render-evidence-file', {
-			detail: {
-				url: url,
-				name: name
-			},
-			composed: true,
-			bubbles: true
-		});
-		this.dispatchEvent(event);
-	}
-
-	_dispatchRenderEvidenceTextEvent(name) {
-		const event = new CustomEvent('d2l-consistent-evaluation-submission-item-render-evidence-text', {
-			detail: {
-				textSubmissionEvidence: {
-					title: `${this.localize('textSubmission')} ${this.displayNumber}`,
-					name: name,
-					date: this._formatDateTime(),
-					downloadUrl: this.attachments[0].properties.href,
-					content: this.comment
-				}
-			},
-			composed: true,
-			bubbles: true
-		});
-		this.dispatchEvent(event);
-	}
-
 	_dispatchToggleEvent(e) {
 		const action = e.target.getAttribute('data-action');
 		const fileId = e.target.getAttribute('data-key');
@@ -297,6 +262,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 		const flagged = file.properties.flagged;
 		const read = file.properties.read;
 		const href = file.properties.href;
+		const id = file.properties.id;
 		return html`
 		<d2l-list-item>
 		<d2l-list-item-content>
@@ -311,7 +277,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 				<span class="d2l-body-small">${this._formatDateTime()}</span>
 			</div>
 		</d2l-list-item-content>
-		${this._addMenuOptions(read, flagged, href)}
+		${this._addMenuOptions(read, flagged, href, id)}
 		</d2l-list-item>`;
 	}
 
@@ -406,7 +372,9 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeMixin(L
 					${this.submissionType === textSubmission ? html`
 						<d2l-menu-item-link text="${this.localize('viewFullSubmission')}"
 							href="javascript:void(0);"
-							@click="${this._dispatchRenderEvidenceTextEvent}"></d2l-menu-item-link>` : null}
+							@click="${
+	// eslint-disable-next-line lit/no-template-arrow
+	() => this._dispatchFileSelectedEvent(id)}"></d2l-menu-item-link>` : null}
 					<d2l-menu-item-link text="${this.localize('download')}" href="${downloadHref}"></d2l-menu-item-link>
 					<d2l-menu-item text="${oppositeReadState}" data-action="${toggleIsReadActionName}" data-key="${id}" @d2l-menu-item-select="${this._dispatchToggleEvent}"></d2l-menu-item>
 					<d2l-menu-item text="${oppositeFlagState}" data-action="${toggleFlagActionName}" data-key="${id}" @d2l-menu-item-select="${this._dispatchToggleEvent}"></d2l-menu-item>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-consistent-evaluation",
-  "version": "0.0.101",
+  "version": "0.0.105",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1123,7 +1123,7 @@
       }
     },
     "@d2l/d2l-attachment": {
-      "version": "github:Brightspace/attachment#7b6e48b5d24b607296cacc9aeb2db6733b410599",
+      "version": "github:Brightspace/attachment#61cb005d6db0fc4ccc444d4c4898e5d1d3a2f46a",
       "from": "github:Brightspace/attachment#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -3911,7 +3911,7 @@
       "dev": true
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#1e0df40a89a0523639d325125cc6ab0902757899",
+      "version": "github:BrightspaceHypermediaComponents/activities#c08851274fdac6835111877cbe0ffb19955050b9",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -3961,7 +3961,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#077c5bce60e701c7262f534ba39c5cb5c1586e78",
+      "version": "github:Brightspace/d2l-activity-alignments#e53497a25a23c2b7eb7e7299c5904d10fc9be604",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -4111,7 +4111,7 @@
       }
     },
     "d2l-facet-filter-sort": {
-      "version": "github:BrightspaceUI/facet-filter-sort#f22674ba3bbbde78c015505263244d54e64b43e9",
+      "version": "github:BrightspaceUI/facet-filter-sort#ecb32711ae3b37fc0426e5fce7ef60c2f794a219",
       "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -4214,7 +4214,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#c2bdab574d3500a8bcbf594108b1718443196d53",
+      "version": "github:BrightspaceUI/navigation#28ea93cc4a27cf96a0c82ab66fb62cfa045847a2",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4244,7 +4244,7 @@
       "from": "github:Brightspace/organization-hm-behavior#semver:^3"
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#e5a12838088d7c3282265d3ccca5fd832319e797",
+      "version": "github:BrightspaceHypermediaComponents/organizations#b214e9e2dd4a75d74521387050277a984fa023da",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4270,17 +4270,15 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#f850f4d12b088a27560bc45beecb6fc45de50b58",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#25d21c45b58ef6cabc452c646c8739c0f57cf3aa",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "requires": {
-        "@brightspace-ui/core": "^1.41.0",
+        "@brightspace-ui/core": "^1",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-hypermedia-constants": "^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
@@ -4347,7 +4345,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#6e42c872e5f7bfde480a5c3ae2135b46fe350bd9",
+      "version": "github:Brightspace/d2l-rubric#a2c53342d8b7d06f3a444581aac2c81d6fb09f45",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
@@ -4397,7 +4395,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#7c55be35d8f7a1867c4ba4493a11402330ed4ca2",
+      "version": "github:BrightspaceHypermediaComponents/sequences#2638e8341dcb13688a157c0a8dcf9c1799fe480a",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",
@@ -11165,7 +11163,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#2c67b1beac87cec1e8d5ba7be0241fa1376d4c40",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#9c672ccde7b6cbd45c2f476d04e890d13acbe029",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
Problem: I started this refactor because I needed the id of the currently displayed file to properly save annotations. This sparked a whole chain of events which lead to this PR. Since I was already in the area I cleaned up a bunch of stuff relating to files.

Solution:

The new way of doing things is we pass `currentFileId` everywhere. This uniquely determines what file is currently being shown. This also has the advantage of us not having to know whether it's text or a file, and passing large amounts of information up in events and down through props.

Now `left-panel` (and below) are the only things that really care if it's text vs file. I tried to make LCB not care at all, but I was held up by the lateness thing. So LCB can take a `fileId` and get the `lateness`.