### PR TITLE
Only load file and strip url the initial load

### DIFF
--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -32,6 +32,9 @@ export class ConsistentEvaluation extends MobxLitElement {
 			fileId: {
 				attribute: 'file-id',
 				type: String
+			},
+			currentFileId: {
+				type: String
 			}
 		};
 	}
@@ -72,17 +75,26 @@ export class ConsistentEvaluation extends MobxLitElement {
 			this._userName = await controller.getUserName();
 			this._iteratorTotal = await controller.getIteratorInfo('total');
 			this._iteratorIndex = await controller.getIteratorInfo('index');
-			this.shadowRoot.querySelector('d2l-consistent-evaluation-page')._setSubmissionsView();
-			this._stripFileIdFromUrl();
+			const stripped = this._stripFileIdFromUrl();
+			if (!stripped) {
+				this.shadowRoot.querySelector('d2l-consistent-evaluation-page')._setSubmissionsView();
+			}
 		}
 	}
 
 	_stripFileIdFromUrl() {
-		const fileIdQueryName = 'fileId';
 		if (this.fileId) {
+			const fileIdQueryName = 'fileId';
 			const urlWithoutFileQuery = window.location.href.replace(`&${fileIdQueryName}=${this.fileId}`, '');
 			history.replaceState({}, document.title, urlWithoutFileQuery);
+
+			this.currentFileId = this.fileId;
+			this.fileId = undefined;
+
+			return true;
 		}
+
+		return false;
 	}
 
 	_onNextStudentClick() {
@@ -112,7 +124,7 @@ export class ConsistentEvaluation extends MobxLitElement {
 				special-access-href=${ifDefined(this._childHrefs && this._childHrefs.specialAccessHref)}
 				return-href=${ifDefined(this.returnHref)}
 				return-href-text=${ifDefined(this.returnHrefText)}
-				current-file-id=${ifDefined(this.fileId)}
+				current-file-id=${ifDefined(this.currentFileId)}
 				.submissionInfo=${this._submissionInfo}
 				.gradeItemInfo=${this._gradeItemInfo}
 				.assignmentName=${this._assignmentName}


### PR DESCRIPTION
Problem: Launching files directly was broken after the files refactor. Digging into it, the problem is the initial load code and the subsequent load code (ie after iteration) are the same. We want to show submissions view after iteration, but not necessarily after the initial load (in the case of direct file launch). 

Solution: I just added another property (`currentFileId`) to pass the file id down and used the original `fileId` property as a flag to determine if this is the first load or not. This also has the advantage of not messing with the browser history stack after every iteration.