### PR TITLE
Add whitespace margins to COA primary panel

### DIFF
--- a/components/left-panel/consistent-evaluation-outcomes-overall-achievement.js
+++ b/components/left-panel/consistent-evaluation-outcomes-overall-achievement.js
@@ -24,10 +24,10 @@ export class ConsistentEvaluationOutcomesOverallAchievement extends LitElement {
 	render() {
 		return html`
 		<div style="margin: 36px ${this._hMargin};">
-            <d2l-coa-primary-panel
-                href=${this.href}
+			<d2l-coa-primary-panel
+				href=${this.href}
 				.token=${this.token}
-            >
+			>
 			</d2l-coa-primary-panel>
 		</div>
 		`;

--- a/components/left-panel/consistent-evaluation-outcomes-overall-achievement.js
+++ b/components/left-panel/consistent-evaluation-outcomes-overall-achievement.js
@@ -1,23 +1,47 @@
 import 'd2l-outcomes-overall-achievement/src/primary-panel/primary-panel.js';
 import { html, LitElement } from 'lit-element';
 
+const HMARGIN_NARROW = '12px';
+const HMARGIN_WIDE = '18px';
+const HMARGIN_PANEL_WIDTH_THRESHOLD_PX = 768;
+
 export class ConsistentEvaluationOutcomesOverallAchievement extends LitElement {
 
 	static get properties() {
 		return {
 			href: { type: String },
-			token: { type: String }
+			token: { type: String },
+			_hMargin: { type: String, attribute: false }
 		};
+	}
+
+	constructor() {
+		super();
+		this._hMargin = HMARGIN_WIDE;
+		window.addEventListener('resize', this._onWindowResize.bind(this));
 	}
 
 	render() {
 		return html`
+		<div style="margin: 36px ${this._hMargin};">
             <d2l-coa-primary-panel
                 href=${this.href}
-                .token=${this.token}
+				.token=${this.token}
             >
-            </d2l-coa-primary-panel>
+			</d2l-coa-primary-panel>
+		</div>
 		`;
+	}
+
+	_onWindowResize() {
+		const boundingRect = this.getBoundingClientRect();
+		const panelWidth = boundingRect.width;
+		if (panelWidth > HMARGIN_PANEL_WIDTH_THRESHOLD_PX) {
+			this._hMargin = HMARGIN_WIDE;
+		}
+		else {
+			this._hMargin = HMARGIN_NARROW;
+		}
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2l-consistent-evaluation",
   "description": "A consistent evaluation page for all tools",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "repository": "https://github.com/BrightspaceHypermediaComponents/consistent-evaluation.git",
   "private": true,
   "scripts": {


### PR DESCRIPTION
On the COA eval page in the LMS, the left panel contents had no whitespace. Per desired specs, this adds vertical margins of 36px and horizontal margins of either 12px or 18px depending on the viewport width of the panel.