### PR TITLE
Make attachments only appear if supported

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -188,6 +188,7 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 		this._dialogOpened = false;
 		this.allowEvaluationWrite = false;
 		this.allowEvaluationDelete = false;
+		this.attachmentsHref = null;
 		this.unsavedChangesHandler = this._confirmUnsavedChangesBeforeUnload.bind(this);
 	}
 
@@ -280,7 +281,7 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 		this.allowEvaluationWrite = this._controller.userHasWritePermission(this.evaluationEntity);
 		this.allowEvaluationDelete = this._controller.userHasDeletePermission(this.evaluationEntity);
 		this.richtextEditorConfig = this._controller.getRichTextEditorConfig(this.evaluationEntity);
-
+		this.attachmentsHref = this._controller.getAttachmentsHref(this.evaluationEntity);
 	}
 
 	_noFeedbackComponent() {
@@ -576,6 +577,7 @@ export default class ConsistentEvaluationPage extends LocalizeMixin(LitElement) 
 						rubric-assessment-href=${ifDefined(this.rubricAssessmentHref)}
 						outcomes-href=${ifDefined(this.outcomesHref)}
 						coa-eval-override-href=${ifDefined(this.coaDemonstrationHref)}
+						attachments-href=${ifDefined(this.attachmentsHref)}
 						.richTextEditorConfig=${this.richtextEditorConfig}
 						.grade=${this._grade}
 						.gradeItemInfo=${this.gradeItemInfo}

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -1,5 +1,5 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
-import { publishActionName, retractActionName, saveActionName, saveFeedbackActionName, saveFeedbackFieldName, saveGradeActionName, saveGradeFieldName, updateActionName } from './constants.js';
+import { attachmentsRel, publishActionName, retractActionName, saveActionName, saveFeedbackActionName, saveFeedbackFieldName, saveGradeActionName, saveGradeFieldName, updateActionName } from './constants.js';
 import { Grade } from '@brightspace-ui-labs/grade-result/src/controller/Grade';
 import { performSirenAction } from 'siren-sdk/src/es6/SirenAction.js';
 import { Rels } from 'd2l-hypermedia-constants';
@@ -141,6 +141,19 @@ export class ConsistentEvaluationController {
 
 		return await this._performAction(evaluationEntity, retractActionName);
 	}
+
+	getAttachmentsHref(entity) {
+		if (!entity) {
+			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
+		}
+
+		if (!entity.hasLinkByRel(attachmentsRel)) {
+			return null;
+		}
+
+		return entity.getLinkByRel(attachmentsRel).href;
+	}
+
 	getRichTextEditorConfig(entity) {
 		if (!entity) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);

--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -106,10 +106,10 @@ export class ConsistentEvaluationHrefController {
 					}
 				}
 			}
-		}
 
-		if (root.hasSubEntityByRel(editSpecialAccessApplicationRel)) {
-			specialAccessHref = root.getSubEntityByRel(editSpecialAccessApplicationRel).properties.path;
+			if (root.hasSubEntityByRel(editSpecialAccessApplicationRel)) {
+				specialAccessHref = root.getSubEntityByRel(editSpecialAccessApplicationRel).properties.path;
+			}
 		}
 
 		return {

--- a/components/controllers/constants.js
+++ b/components/controllers/constants.js
@@ -7,6 +7,7 @@ export const saveFeedbackActionName = 'SaveFeedback';
 export const saveGradeActionName = 'SaveGrade';
 export const saveFeedbackFieldName = 'value';
 export const saveGradeFieldName = 'value';
+export const attachmentsRel = 'https://activities.api.brightspace.com/rels/attachments';
 export const gradesRel = 'https://activities.api.brightspace.com/rels/grade';
 export const groupRel = 'https://api.brightspace.com/rels/group';
 export const feedbackRel = 'https://activities.api.brightspace.com/rels/feedback';

--- a/components/right-panel/consistent-evaluation-feedback-presentational.js
+++ b/components/right-panel/consistent-evaluation-feedback-presentational.js
@@ -12,6 +12,10 @@ import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElement) {
 	static get properties() {
 		return {
+			attachmentsHref: {
+				attribute: 'attachments-href',
+				type: String
+			},
 			canEditFeedback: {
 				attribute: 'can-edit-feedback',
 				type: Boolean
@@ -53,6 +57,7 @@ class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElemen
 		this.canEditFeedback = false;
 		this._debounceJobs = {};
 		this.flush = this.flush.bind(this);
+		this.attachmentsHref = null;
 	}
 
 	htmlEditorEnabled(e) {
@@ -114,28 +119,32 @@ class ConsistentEvaluationFeedbackPresentational extends LocalizeMixin(LitElemen
 
 	render() {
 		if (this.href && this.token) {
-
-			return html`
-			<div class="d2l-evaluation-feedback-container">
-				<d2l-consistent-evaluation-right-panel-block title="${this.localize('overallFeedback')}">
-					<d2l-activity-text-editor
-						.key="${this._key}"
-						.value="${this.feedbackText}"
-						.richtextEditorConfig="${this.richTextEditorConfig}"
-						@d2l-activity-text-editor-change="${this._saveOnFeedbackChange}"
-						ariaLabel="${this.localize('overallFeedback')}">
-					</d2l-activity-text-editor>
+			const attachments = this.attachmentsHref !== null
+				? html`
 					<div>
 						<d2l-consistent-evaluation-attachments-editor
-							href="${this.href}/attachments"
+							href=${this.attachmentsHref}
 							.token="${this.token}"
 							destinationHref="${this.href}"
 							.canEditFeedback="${this.canEditFeedback}">
 						</d2l-consistent-evaluation-attachments-editor>
-					</div>
-				</d2l-consistent-evaluation-right-panel-block>
-			</div>
-		`;
+					</div>`
+				: null;
+
+			return html`
+				<div class="d2l-evaluation-feedback-container">
+					<d2l-consistent-evaluation-right-panel-block title="${this.localize('overallFeedback')}">
+						<d2l-activity-text-editor
+							.key="${this._key}"
+							.value="${this.feedbackText}"
+							.richtextEditorConfig="${this.richTextEditorConfig}"
+							@d2l-activity-text-editor-change="${this._saveOnFeedbackChange}"
+							ariaLabel="${this.localize('overallFeedback')}">
+						</d2l-activity-text-editor>
+						${attachments}
+					</d2l-consistent-evaluation-right-panel-block>
+				</div>
+			`;
 		} else {
 			return html``;
 		}

--- a/components/right-panel/consistent-evaluation-right-panel.js
+++ b/components/right-panel/consistent-evaluation-right-panel.js
@@ -17,6 +17,10 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 				attribute: 'allow-evaluation-write',
 				type: Boolean
 			},
+			attachmentsHref: {
+				attribute: 'attachments-href',
+				type: String
+			},
 			feedbackText: {
 				attribute: false
 			},
@@ -101,6 +105,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 		this.hideCoaOverride = false;
 		this.allowEvaluationWrite = false;
 		this.rubricOpen = false;
+		this.attachmentsHref = null;
 	}
 
 	_renderRubric() {
@@ -155,6 +160,7 @@ export class ConsistentEvaluationRightPanel extends LocalizeMixin(LitElement) {
 					?can-edit-feedback=${this.allowEvaluationWrite}
 					.feedbackText=${this.feedbackText}
 					.richTextEditorConfig=${this.richTextEditorConfig}
+					attachments-href=${ifDefined(this.attachmentsHref)}
 				></d2l-consistent-evaluation-feedback-presentational>
 			`;
 		}

--- a/demo/consistent-evaluation-feedback.html
+++ b/demo/consistent-evaluation-feedback.html
@@ -17,10 +17,24 @@
 	<body class="d2l-typography">
 		<d2l-demo-page page-title="consistent-evaluation-feedback-presentational">
 
+			<h2>Standard</h2>
 			<d2l-demo-snippet>
 				<d2l-consistent-evaluation-feedback-presentational
 					can-edit-feedback
 					feedback-text="This is where you can add feedback!"
+					href="data/grade/evaluationEntity.json"
+					token='"abc123"'
+					attachments-href="data/grade/attachments.json"
+				></d2l-consistent-evaluation-feedback-presentational>
+			</d2l-demo-snippet>
+
+			<h2>No Attachments</h2>
+			<d2l-demo-snippet>
+				<d2l-consistent-evaluation-feedback-presentational
+					can-edit-feedback
+					feedback-text="This is where you can add feedback!"
+					href="data/grade/evaluationEntity.json"
+					token='"abc123"'
 				></d2l-consistent-evaluation-feedback-presentational>
 			</d2l-demo-snippet>
 

--- a/demo/data/grade/attachments.json
+++ b/demo/data/grade/attachments.json
@@ -1,0 +1,78 @@
+{
+    "class": [
+        "collection",
+        "attachments"
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://files.api.brightspace.com/rels/files"
+            ],
+            "href": "about:blank"
+        }
+    ],
+    "actions": [
+        {
+            "class": [
+                "add-feedback-attachment"
+            ],
+            "title": "Add file",
+            "href": "about:blank",
+            "name": "add-file",
+            "method": "PATCH",
+            "fields": [
+                {
+                    "type": "hidden",
+                    "name": "provider",
+                    "value": "feedback-attachments"
+                },
+                {
+                    "type": "hidden",
+                    "name": "type",
+                    "value": "add-file"
+                },
+                {
+                    "type": "text",
+                    "title": "add-file",
+                    "name": "value",
+                    "value": "{\"FileSystemType\":\"{fileSystemType}\",\"FileId\":\"{fileId}\"}"
+                },
+                {
+                    "type": "hidden",
+                    "name": "currentState"
+                }
+            ]
+        },
+        {
+            "class": [
+                "add-feedback-text-attachment"
+            ],
+            "title": "Add Text file",
+            "href": "about:blank",
+            "name": "add-text-file",
+            "method": "PATCH",
+            "fields": [
+                {
+                    "type": "hidden",
+                    "name": "provider",
+                    "value": "feedback-attachments"
+                },
+                {
+                    "type": "hidden",
+                    "name": "type",
+                    "value": "add-text-file"
+                },
+                {
+                    "type": "text",
+                    "title": "add-text-file",
+                    "name": "value",
+                    "value": "{\"FileName\":\"{fileName}\",\"FileContents\":\"{fileContents}\"}"
+                },
+                {
+                    "type": "hidden",
+                    "name": "currentState"
+                }
+            ]
+        }
+    ]
+}

--- a/demo/data/grade/evaluationEntity.json
+++ b/demo/data/grade/evaluationEntity.json
@@ -93,7 +93,7 @@
       "rel": [
         "https://activities.api.brightspace.com/rels/attachments"
       ],
-      "href": "https://41c25168-e162-4d7c-b031-5a30e2dda04a.activities.api.proddev.d2l/activities/6606_2000_1/usages/6609/users/user_10183/evaluation/attachments"
+      "href": "/demo/data/grade/attachments.json"
     },
     {
       "rel": [


### PR DESCRIPTION
Don't want attachments in right panel for COA eval.
Goes along with this API change: https://github.com/Brightspace/lms/pull/2746