### PR TITLE
Abedley/annotations/actually save

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -16,6 +16,7 @@ import { Awaiter } from './awaiter.js';
 import { ConsistentEvaluationController } from './controllers/ConsistentEvaluationController.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeConsistentEvaluation } from '../lang/localize-consistent-evaluation.js';
+import { performSirenAction } from 'siren-sdk/src/es6/SirenAction.js';
 
 const DIALOG_ACTION_LEAVE = 'leave';
 
@@ -526,8 +527,23 @@ export default class ConsistentEvaluationPage extends LocalizeConsistentEvaluati
 		this._showScrollbars();
 	}
 
-	async _handleAnnotationsUpdate() {
+	async _handleAnnotationsUpdate(e) {
+		const entity = await this._controller.fetchEvaluationEntity(false);
+		const annotationsEntity = entity.getSubEntityByRel('annotations');
+		const saveAnnotationsAction = annotationsEntity.getActionByName('SaveAnnotations');
 
+		const annotationsData = e.detail;
+		const encodedAnnotationsData = {
+			FileId: this.currentFileId,
+			AnnotationsData: JSON.stringify(annotationsData)
+		};
+
+		const fields = [{
+			name: 'value',
+			value: JSON.stringify(encodedAnnotationsData)
+		}];
+
+		this.evaluationEntity = await performSirenAction(this.token, saveAnnotationsAction, fields, true);
 	}
 
 	connectedCallback() {

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -110,6 +110,23 @@ export class ConsistentEvaluationController {
 		return await this._performAction(targetEntity, saveGradeActionName, saveGradeFieldName, gradeValue);
 	}
 
+	async transientSaveAnnotations(evaluationEntity, annotationsData, fileId) {
+		const annotationsEntity = evaluationEntity.getSubEntityByRel('annotations');
+		const saveAnnotationsAction = annotationsEntity.getActionByName('SaveAnnotations');
+
+		const encodedAnnotationsData = {
+			FileId: fileId,
+			AnnotationsData: JSON.stringify(annotationsData)
+		};
+
+		const fields = [{
+			name: 'value',
+			value: JSON.stringify(encodedAnnotationsData)
+		}];
+
+		return await performSirenAction(this.token, saveAnnotationsAction, fields, true);
+	}
+
 	async save(evaluationEntity) {
 		if (!evaluationEntity) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-consistent-evaluation",
-  "version": "0.0.112",
+  "version": "0.0.122",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1123,7 +1123,7 @@
       }
     },
     "@d2l/d2l-attachment": {
-      "version": "github:Brightspace/attachment#7b6e48b5d24b607296cacc9aeb2db6733b410599",
+      "version": "github:Brightspace/attachment#61cb005d6db0fc4ccc444d4c4898e5d1d3a2f46a",
       "from": "github:Brightspace/attachment#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -3911,7 +3911,7 @@
       "dev": true
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#1e0df40a89a0523639d325125cc6ab0902757899",
+      "version": "github:BrightspaceHypermediaComponents/activities#c08851274fdac6835111877cbe0ffb19955050b9",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -3961,7 +3961,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#077c5bce60e701c7262f534ba39c5cb5c1586e78",
+      "version": "github:Brightspace/d2l-activity-alignments#e53497a25a23c2b7eb7e7299c5904d10fc9be604",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -4111,7 +4111,7 @@
       }
     },
     "d2l-facet-filter-sort": {
-      "version": "github:BrightspaceUI/facet-filter-sort#f22674ba3bbbde78c015505263244d54e64b43e9",
+      "version": "github:BrightspaceUI/facet-filter-sort#ecb32711ae3b37fc0426e5fce7ef60c2f794a219",
       "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -4214,7 +4214,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#c2bdab574d3500a8bcbf594108b1718443196d53",
+      "version": "github:BrightspaceUI/navigation#28ea93cc4a27cf96a0c82ab66fb62cfa045847a2",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4244,7 +4244,7 @@
       "from": "github:Brightspace/organization-hm-behavior#semver:^3"
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#e5a12838088d7c3282265d3ccca5fd832319e797",
+      "version": "github:BrightspaceHypermediaComponents/organizations#b214e9e2dd4a75d74521387050277a984fa023da",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4270,17 +4270,15 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#f850f4d12b088a27560bc45beecb6fc45de50b58",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#25d21c45b58ef6cabc452c646c8739c0f57cf3aa",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "requires": {
-        "@brightspace-ui/core": "^1.41.0",
+        "@brightspace-ui/core": "^1",
         "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
         "d2l-hypermedia-constants": "^6",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
@@ -4347,7 +4345,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#6e42c872e5f7bfde480a5c3ae2135b46fe350bd9",
+      "version": "github:Brightspace/d2l-rubric#a2c53342d8b7d06f3a444581aac2c81d6fb09f45",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
@@ -4397,7 +4395,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#7c55be35d8f7a1867c4ba4493a11402330ed4ca2",
+      "version": "github:BrightspaceHypermediaComponents/sequences#2638e8341dcb13688a157c0a8dcf9c1799fe480a",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",
@@ -11165,7 +11163,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#2c67b1beac87cec1e8d5ba7be0241fa1376d4c40",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#9c672ccde7b6cbd45c2f476d04e890d13acbe029",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
Problem: Annotations aren't being saved in CE
Solution: This is the first PR to cover the majority of cases. Basically, now that we've added an API route for annotations similar to grades/feedback, I just implemented annotations in the same way.

The reason more work is needed is because annotatations are file-specific (vs grades or feedback which are specific to the entire evaluation). Thus we need to prompt users when changing files, because they will lose their transiently saved annotations data. That feature is not included in this PR as I will need API changes to detect if I have unsaved annotations data.