### PR TITLE
Bypassing cache when fetching attachments

### DIFF
--- a/components/right-panel/consistent-evaluation-attachments-editor.js
+++ b/components/right-panel/consistent-evaluation-attachments-editor.js
@@ -67,7 +67,7 @@ class ConsistentEvaluationAttachmentsEditor extends LitElement {
 	async _init(href, token) {
 		const tempAttachments = [];
 		let promises = [];
-		const entity = await window.D2L.Siren.EntityStore.fetch(href, token);
+		const entity = await window.D2L.Siren.EntityStore.fetch(href, token, true);
 		if (entity && entity.entity && entity.entity.entities) {
 			const entities = entity.entity.entities;
 			promises = entities.map(attachmentEntity => {


### PR DESCRIPTION
Problem:  When you attach a file and then publish or save draft the attached file is removed from the ui (its saved correctly)

Solution: No longer hit the cache when fetching file attachments

I think this is an easy fix, but exposes some issues with our overall design.  Ideally we don't re-fetch the attachment list after publish since we already know what is attached. 