### PR TITLE
Save coa-eval-override component prior to publishing evaluation

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -179,6 +179,20 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		this.unsavedChangesHandler = this._confirmUnsavedChangesBeforeUnload.bind(this);
 	}
 
+	get coaDemonstrationHref() {
+		return this._coaDemonstrationHref;
+	}
+
+	set coaDemonstrationHref(val) {
+		const oldVal = this.coaDemonstrationHref;
+		if (oldVal !== val) {
+			this._coaDemonstrationHref = val;
+			if (this._coaDemonstrationHref && this._token) {
+				this._initializeController();
+			}
+		}
+	}
+
 	get evaluationEntity() {
 		return this._evaluationEntity;
 	}
@@ -201,20 +215,6 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			this._evaluationHref = val;
 			if (this._evaluationHref && this._token) {
 				this._initializeController().then(() => this.requestUpdate());
-			}
-		}
-	}
-
-	get coaDemonstrationHref() {
-		return this._coaDemonstrationHref;
-	}
-
-	set coaDemonstrationHref(val) {
-		const oldVal = this.coaDemonstrationHref;
-		if (oldVal !== val) {
-			this._coaDemonstrationHref = val;
-			if (this._coaDemonstrationHref && this._token) {
-				this._initializeController();
 			}
 		}
 	}
@@ -360,7 +360,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		);
 	}
 
-	async _transientSaveCoaEvalOverride(e) {
+	async _transientSaveCoaEvalOverride() {
 		// Call transientSaveFeedback to 'unsave' the evaluation
 		await this._mutex.dispatch(
 			async() => {

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -657,7 +657,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 						?allow-evaluation-write=${this._allowEvaluationWrite()}
 						@on-d2l-consistent-eval-feedback-edit=${this._transientSaveFeedback}
 						@on-d2l-consistent-eval-grade-changed=${this._transientSaveGrade}
-						@d2l-outcomes-coa-eval-override-item-selected=${this._transientSaveCoaEvalOverride}
+						@d2l-outcomes-coa-eval-override-change=${this._transientSaveCoaEvalOverride}
 					></consistent-evaluation-right-panel>
 				</div>
 				<div slot="footer">

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -224,7 +224,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 
 	get _feedbackText() {
 		if (this._feedbackEntity && this._feedbackEntity.properties) {
-			return this._feedbackEntity.properties.html || '';
+			return this._feedbackEntity.properties.html || this._feedbackEntity.properties.text || '';
 		}
 		return undefined;
 	}
@@ -352,13 +352,11 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 	async _transientSaveCoaEvalOverride(e) {
 		const action = e.detail.action;
 		this._pendingSaveActions.coaEvalOverride = action.name === 'select' ? e.detail.action : undefined;
-		// Call transientSaveFeedback for the evaluation to be unsaved
+		// Call transientSaveFeedback to 'unsave' the evaluation
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
-				const feedbackEntity = entity.getSubEntityByRel('feedback');
-				const feedbackVal = feedbackEntity.properties.html;
-				this.evaluationEntity = await this._controller.transientSaveFeedback(entity, feedbackVal);
+				this.evaluationEntity = await this._controller.transientSaveFeedback(entity, this._feedbackText);
 			}
 		);
 	}

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -357,7 +357,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
 				const feedbackEntity = entity.getSubEntityByRel('feedback');
-				const feedbackVal = feedbackEntity.properties.text;
+				const feedbackVal = feedbackEntity.properties.html;
 				this.evaluationEntity = await this._controller.transientSaveFeedback(entity, feedbackVal);
 			}
 		);

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -187,8 +187,8 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		const oldVal = this.coaDemonstrationHref;
 		if (oldVal !== val) {
 			this._coaDemonstrationHref = val;
-			if (this._coaDemonstrationHref && this._token) {
-				this._initializeController();
+			if (this._evaluationHref && this._coaDemonstrationHref && this._token) {
+				this._initializeController().then(() => this.requestUpdate());
 			}
 		}
 	}

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -275,7 +275,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 	}
 
 	async _initializeController() {
-		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._coaDemonstrationHref, this._token);
+		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._token, this._coaDemonstrationHref);
 		const bypassCache = true;
 		this.evaluationEntity = await this._controller.fetchEvaluationEntity(bypassCache);
 		this.evaluationState = this.evaluationEntity.properties.state;

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -275,7 +275,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 	}
 
 	async _initializeController() {
-		this._controller = new ConsistentEvaluationController(this._evaluationHref, this.coaDemonstrationHref, this._token);
+		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._coaDemonstrationHref, this._token);
 		const bypassCache = true;
 		this.evaluationEntity = await this._controller.fetchEvaluationEntity(bypassCache);
 		this.evaluationState = this.evaluationEntity.properties.state;

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -164,7 +164,7 @@ export class ConsistentEvaluationController {
 			return;
 		}
 
-		const sirenActions = Object.values(saveActions).map(async (action) => {
+		const sirenActions = Object.values(saveActions).map(async(action) => {
 			if (action) {
 				return this._performSirenAction(action);
 			}

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -146,7 +146,9 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) await this.saveCoaDemonstration();
+		if (this.coaDemonstrationHref) {
+			await this.saveCoaDemonstration();
+		}
 		return await this._performAction(evaluationEntity, saveActionName);
 	}
 
@@ -155,7 +157,9 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) await this.saveCoaDemonstration();
+		if (this.coaDemonstrationHref) {
+			await this.saveCoaDemonstration();
+		}
 		return await this._performAction(evaluationEntity, updateActionName);
 	}
 
@@ -164,7 +168,9 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) await this.saveCoaDemonstration();
+		if (this.coaDemonstrationHref) {
+			await this.saveCoaDemonstration();
+		}
 		return await this._performAction(evaluationEntity, publishActionName);
 	}
 
@@ -173,7 +179,9 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) await this.saveCoaDemonstration();
+		if (this.coaDemonstrationHref) {
+			await this.saveCoaDemonstration();
+		}
 		return await this._performAction(evaluationEntity, retractActionName);
 	}
 

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -159,6 +159,20 @@ export class ConsistentEvaluationController {
 		return await this._performAction(evaluationEntity, retractActionName);
 	}
 
+	async performSaveActions(saveActions) {
+		if (!saveActions) {
+			return;
+		}
+
+		const sirenActions = Object.values(saveActions).map(async (action) => {
+			if (action) {
+				return this._performSirenAction(action);
+			}
+		});
+
+		return await Promise.all(sirenActions);
+	}
+
 	getAttachmentsHref(entity) {
 		if (!entity) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -17,7 +17,7 @@ export const ConsistentEvaluationControllerErrors = {
 };
 
 export class ConsistentEvaluationController {
-	constructor(evaluationHref, coaDemonstrationHref, token) {
+	constructor(evaluationHref, token, coaDemonstrationHref = undefined) {
 		if (!evaluationHref) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_HREF);
 		}


### PR DESCRIPTION
Related: https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/58
Unlike the achievements selector in the `consistent-evaluation-outcomes` component, the achievements selector in the `coa-eval-override` component does not autosave, and fires an event with the corresponding "select" action instead.
Changes:
* Add a listener when an outcome in `coa-eval-override` is selected which "unsaves" the evaluation
* Prior to saving/updating/publishing an evaluation, publish the COA demonstration (if applicable)

This should not change any functionality in any tool other than in Mastery View.