### PR TITLE
Fix hidden feedback attachments

### DIFF
--- a/components/right-panel/consistent-evaluation-right-panel.js
+++ b/components/right-panel/consistent-evaluation-right-panel.js
@@ -96,7 +96,6 @@ export class ConsistentEvaluationRightPanel extends LocalizeConsistentEvaluation
 		this.hideCoaOverride = false;
 		this.allowEvaluationWrite = false;
 		this.rubricOpen = false;
-		this.attachmentsHref = null;
 		window.D2L.DialogMixin.preferNative = false;
 	}
 


### PR DESCRIPTION
Should not be initialized as null. When left uninitialized instead, will have the value undefined and will
not insert 'null' as invalid href string