### PR TITLE
Navbar title style + markup

### DIFF
--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -54,7 +54,6 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 			}
 			.d2l-heading-3 {
 				padding-top: 0.25rem;
-				font-style: normal !important;
 			}
 			.d2l-truncate {
 				overflow: hidden;

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -6,7 +6,7 @@ import '@brightspace-ui/core/components/tooltip/tooltip.js';
 
 import { css, html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
-import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { heading3Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeConsistentEvaluation } from '../../lang/localize-consistent-evaluation.js';
 
 class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement) {
@@ -44,7 +44,7 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 	}
 
 	static get styles() {
-		return [labelStyles, css`
+		return [labelStyles, heading3Styles, css`
 			.d2l-short-back {
 				display: none;
 			}
@@ -54,12 +54,17 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 			}
 			.d2l-heading-3 {
 				padding-top: 0.25rem;
+				font-style: normal !important;
 			}
 			.d2l-truncate {
 				overflow: hidden;
 				overflow-wrap: break-word;
 				text-overflow: ellipsis;
 				white-space: nowrap;
+			}
+			
+			h1 {
+				margin: 0rem !important;
 			}
 
 			@media (max-width: 929px) {
@@ -160,7 +165,7 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 				</div>
 
 				<div slot="middle">
-					<div id="titleName" class="d2l-heading-3 d2l-truncate">${this.titleName}</div>
+					<h1 id="titleName" class="d2l-heading-3 d2l-truncate">${this.titleName}</h1>
 					<div id="subtitleName" class="d2l-label-text d2l-truncate">${this.subtitleName}</div>
 					<d2l-tooltip for="titleName"> ${this.titleName}</d2l-tooltip>
 					<d2l-tooltip for="subtitleName">${this.subtitleName}</d2l-tooltip>


### PR DESCRIPTION
Changes the title of the middle navbar segment to be marked up as a heading, allowing screen reader users to quickly navigate to it. Also fixes the application of the d2l-heading-3 typography style to this title.