### PR TITLE
Nullcheck COA publish action

### DIFF
--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -188,6 +188,8 @@ export class ConsistentEvaluationController {
 	async saveCoaDemonstration() {
 		const coaDemonstrationEntity = await this.fetchCoaDemonstrationEntity(false);
 		const publishAction = coaDemonstrationEntity.getActionByName('publish');
-		return await this._performSirenAction(publishAction);
+		if (publishAction) {
+			return await this._performSirenAction(publishAction);
+		}
 	}
 }


### PR DESCRIPTION
In the COA Manual Override page, when only publishing feedback with an achievement selector, the evaluation fails to publish since publish action is null and there is no nullcheck.

Changes:
* Add a nullcheck to `publishAction` in saveCoaDemonstration