### PR TITLE
make student name heading level 2

### DIFF
--- a/components/header/d2l-consistent-evaluation-lcb-user-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-user-context.js
@@ -100,7 +100,7 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 	render() {
 		return html`
 			${this._renderProfileImage()}
-			<span class="d2l-body-compact d2l-consistent-evaluation-lcb-user-name">${ifDefined(this._displayName)}</span>
+			<h2 class="d2l-body-compact d2l-consistent-evaluation-lcb-user-name">${ifDefined(this._displayName)}</h2>
 			${this._getExemptText()}
 		`;
 	}


### PR DESCRIPTION
[US122306](https://rally1.rallydev.com/#/detail/userstory/455120973556?fdp=true): A11y - Use of Headers

So essentially we want 3 items on the page to have heading levels assigned:
- Assignment Name = 1
- Student Name = 2
- Submission Name = 3

This PR just adds level 2 to student name.

Jamie M previously added level 1 to assignment name, 3 days ago: https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/commit/253f4e1a30164ccf8c96cdc5ee7f7400c6801f26#diff-580e82674cf3dc7a9b4cea996e56e70d7f5762ef61dca744ba8e7e42aa0924e3R178

And level 3 was already on submission name: 
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/blob/master/components/left-panel/consistent-evaluation-submission-item.js#L268

https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/blob/master/components/left-panel/consistent-evaluation-submission-item.js#L293