### PR TITLE
Add in not great way to refresh the file selector after a declined discard of annotations

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -594,6 +594,9 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			}
 		} else {
 			// need to reset the file selector
+			await this.shadowRoot.querySelector('d2l-consistent-evaluation-learner-context-bar')
+				.shadowRoot.querySelector('d2l-consistent-evaluation-lcb-file-context')
+				.refreshSelect();
 		}
 	}
 

--- a/components/header/d2l-consistent-evaluation-lcb-file-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-file-context.js
@@ -163,6 +163,10 @@ export class ConsistentEvaluationLcbFileContext extends RtlMixin(LocalizeConsist
 		return  `${fileName.substring(0, maxFileLength)}…${ext}`;
 	}
 
+	refreshSelect() {
+		this.shadowRoot.querySelector('select').value = this.currentFileId;
+	}
+
 	render() {
 		if (!this._files || this._files.length === 0) {
 			return html ``;


### PR DESCRIPTION
As promised, here's follow up 2 from the previous PR. This adds a super hacky way of keeping the file selector in-sync with the currently selected file. The problem is the UI change of selecting a different file changes the UI state, but since the `currentFileId` does not change, Lit does not re-render. Thus we need to manually tell it "hey actually we need you to display the file that corresponds to your `currentFileId`"