### PR TITLE
Remove COA demonstration entity from controller

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -169,7 +169,6 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		moment.relativeTimeRounding(Math.floor);
 
 		this._evaluationHref = undefined;
-		this._coaDemonstrationHref = undefined;
 		this._token = undefined;
 		this._controller = undefined;
 		this._evaluationEntity = undefined;
@@ -178,20 +177,6 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		this._mutex = new Awaiter();
 		this._unsavedChangesDialogOpened = false;
 		this.unsavedChangesHandler = this._confirmUnsavedChangesBeforeUnload.bind(this);
-	}
-
-	get coaDemonstrationHref() {
-		return this._coaDemonstrationHref;
-	}
-
-	set coaDemonstrationHref(val) {
-		const oldVal = this.coaDemonstrationHref;
-		if (oldVal !== val) {
-			this._coaDemonstrationHref = val;
-			if (this._evaluationHref && this._coaDemonstrationHref && this._token) {
-				this._initializeController().then(() => this.requestUpdate());
-			}
-		}
 	}
 
 	get evaluationEntity() {
@@ -276,7 +261,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 	}
 
 	async _initializeController() {
-		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._token, this._coaDemonstrationHref);
+		this._controller = new ConsistentEvaluationController(this._evaluationHref, this._token);
 		const bypassCache = true;
 		this.evaluationEntity = await this._controller.fetchEvaluationEntity(bypassCache);
 	}
@@ -631,10 +616,14 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		super.disconnectedCallback();
 	}
 
-	_fireSaveEvaluationEvent() {
+	async _fireSaveEvaluationEvent() {
+		const entity = await this._controller.fetchEvaluationEntity(false);
 		window.dispatchEvent(new CustomEvent('d2l-save-evaluation', {
 			composed: true,
-			bubbles: true
+			bubbles: true,
+			detail: {
+				evaluationEntity: entity
+			}
 		}));
 	}
 

--- a/components/controllers/ConsistentEvaluationController.js
+++ b/components/controllers/ConsistentEvaluationController.js
@@ -17,7 +17,7 @@ export const ConsistentEvaluationControllerErrors = {
 };
 
 export class ConsistentEvaluationController {
-	constructor(evaluationHref, token, coaDemonstrationHref = undefined) {
+	constructor(evaluationHref, token) {
 		if (!evaluationHref) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_HREF);
 		}
@@ -27,7 +27,6 @@ export class ConsistentEvaluationController {
 		}
 
 		this.evaluationHref = evaluationHref;
-		this.coaDemonstrationHref = coaDemonstrationHref;
 		this.token = token;
 	}
 
@@ -43,20 +42,6 @@ export class ConsistentEvaluationController {
 		const evaluationEntity = evaluationResource.entity;
 
 		return evaluationEntity;
-	}
-
-	async _fetchCoaDemonstrationEntity(bypassCache) {
-		return await window.D2L.Siren.EntityStore.fetch(this.coaDemonstrationHref, this.token, bypassCache);
-	}
-
-	async fetchCoaDemonstrationEntity(bypassCache = false) {
-		const coaDemonstrationResource = await this._fetchCoaDemonstrationEntity(bypassCache);
-		if (!coaDemonstrationResource || !coaDemonstrationResource.entity) {
-			throw new Error(ConsistentEvaluationControllerErrors.ERROR_FETCHING_ENTITY);
-		}
-		const coaDemonstrationEntity = coaDemonstrationResource.entity;
-
-		return coaDemonstrationEntity;
 	}
 
 	async _performSirenAction(action, field = null) {
@@ -157,9 +142,6 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) {
-			await this.saveCoaDemonstration();
-		}
 		return await this._performAction(evaluationEntity, saveActionName);
 	}
 
@@ -168,19 +150,12 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) {
-			await this.saveCoaDemonstration();
-		}
 		return await this._performAction(evaluationEntity, updateActionName);
 	}
 
 	async publish(evaluationEntity) {
 		if (!evaluationEntity) {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
-		}
-
-		if (this.coaDemonstrationHref) {
-			await this.saveCoaDemonstration();
 		}
 		return await this._performAction(evaluationEntity, publishActionName);
 	}
@@ -190,17 +165,6 @@ export class ConsistentEvaluationController {
 			throw new Error(ConsistentEvaluationControllerErrors.INVALID_EVALUATION_ENTITY);
 		}
 
-		if (this.coaDemonstrationHref) {
-			await this.saveCoaDemonstration();
-		}
 		return await this._performAction(evaluationEntity, retractActionName);
-	}
-
-	async saveCoaDemonstration() {
-		const coaDemonstrationEntity = await this.fetchCoaDemonstrationEntity(false);
-		const publishAction = coaDemonstrationEntity.getActionByName('publish');
-		if (publishAction) {
-			return await this._performSirenAction(publishAction);
-		}
 	}
 }


### PR DESCRIPTION
These 3 PRs are related to each other:
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/181
https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/64
https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/59

Recently, the COA `publish` action now has a field that requires knowledge of the state of the COA component and the feedback contents. As a result, the `publish` action is now moved to the COA component itself and is called using the `d2l-save-evaluation` event.

Changes:
* Remove any COA-related logic in the `ConsistentEvaluationController`
* Pass in the evaluation entity to the `d2l-save-evaluation` event for the COA component to use for its `publish` action.

https://rally1.rallydev.com/#/detail/defect/455925703800?fdp=true
