### PR TITLE
Add promise array to consistent-eval-page

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -177,6 +177,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		this._mutex = new Awaiter();
 		this._unsavedChangesDialogOpened = false;
 		this.unsavedChangesHandler = this._confirmUnsavedChangesBeforeUnload.bind(this);
+		this._savePromises = [];
 	}
 
 	get evaluationEntity() {
@@ -339,8 +340,12 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 		);
 	}
 
-	async _transientSaveCoaEvalOverride() {
+	async _transientSaveCoaEvalOverride(e) {
 		// Call transientSaveFeedback to 'unsave' the evaluation
+		if (e.detail && e.detail.sirenActionPromise) {
+			this._addSavePromise(e.detail.sirenActionPromise);
+		}
+
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
@@ -355,6 +360,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			bubbles: true
 		}));
 
+		await this._awaitAllSavePromises();
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
@@ -375,6 +381,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			bubbles: true
 		}));
 
+		await this._awaitAllSavePromises();
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
@@ -395,6 +402,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			bubbles: true
 		}));
 
+		await this._awaitAllSavePromises();
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
@@ -416,6 +424,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			bubbles: true
 		}));
 
+		await this._awaitAllSavePromises();
 		await this._mutex.dispatch(
 			async() => {
 				const entity = await this._controller.fetchEvaluationEntity(false);
@@ -429,6 +438,15 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 				this.submissionInfo.evaluationState = draftState;
 			}
 		);
+	}
+
+	_addSavePromise(promise) {
+		this._savePromises.push(promise);
+	}
+
+	async _awaitAllSavePromises() {
+		await Promise.all(this._savePromises);
+		this._savePromises = [];
 	}
 
 	_showToast(message) {

--- a/components/transient-save-awaiter.js
+++ b/components/transient-save-awaiter.js
@@ -1,16 +1,16 @@
 export class TransientSaveAwaiter {
-    constructor() {
-        this._pendingTransientSaves = [];
-    }
+	constructor() {
+		this._pendingTransientSaves = [];
+	}
 
-    addTransientSave(promise) {
-        this._pendingTransientSaves.push(promise);
-        return this._pendingTransientSaves;
+	addTransientSave(promise) {
+		this._pendingTransientSaves.push(promise);
+		return this._pendingTransientSaves;
 	}
 
 	async awaitAllTransientSaves() {
-        const resolvedSaves = await Promise.all(this._pendingTransientSaves);
-        this._pendingTransientSaves = [];
-        return resolvedSaves;
+		const resolvedSaves = await Promise.all(this._pendingTransientSaves);
+		this._pendingTransientSaves = [];
+		return resolvedSaves;
 	}
 }

--- a/components/transient-save-awaiter.js
+++ b/components/transient-save-awaiter.js
@@ -1,0 +1,16 @@
+export class TransientSaveAwaiter {
+    constructor() {
+        this._pendingTransientSaves = [];
+    }
+
+    addTransientSave(promise) {
+        this._pendingTransientSaves.push(promise);
+        return this._pendingTransientSaves;
+	}
+
+	async awaitAllTransientSaves() {
+        const resolvedSaves = await Promise.all(this._pendingTransientSaves);
+        this._pendingTransientSaves = [];
+        return resolvedSaves;
+	}
+}

--- a/components/transient-save-awaiter.js
+++ b/components/transient-save-awaiter.js
@@ -3,13 +3,19 @@ export class TransientSaveAwaiter {
 		this._pendingTransientSaves = [];
 	}
 
-	addTransientSave(promise) {
-		this._pendingTransientSaves.push(promise);
+	addTransientSave(transientSave) {
+		this._pendingTransientSaves.push(transientSave);
 		return this._pendingTransientSaves;
 	}
 
 	async awaitAllTransientSaves() {
-		const resolvedSaves = await Promise.all(this._pendingTransientSaves);
+		let resolvedSaves;
+		try {
+			resolvedSaves = await Promise.all(this._pendingTransientSaves);
+		} catch (err) {
+			this._pendingTransientSaves = [];
+			throw err;
+		}
 		this._pendingTransientSaves = [];
 		return resolvedSaves;
 	}

--- a/test/transient-save-awaiter.test.js
+++ b/test/transient-save-awaiter.test.js
@@ -1,0 +1,51 @@
+import { assert } from '@open-wc/testing';
+import { TransientSaveAwaiter } from '../components/transient-save-awaiter.js';
+
+describe('Awaiter', () => {
+	it('should add and await actions properly', async() => {
+		const awaiter = new TransientSaveAwaiter();
+		const action1 = async() => {
+			return 'one';
+		};
+		const action2 = async() => {
+			return 'two';
+		};
+		const action3 = () => {
+			return 'three';
+		};
+
+		const promise1 = action1();
+		const promise2 = action2();
+
+		const notAPromise1 = action3();
+		const notAPromise2 = 'four';
+
+		awaiter.addTransientSave(promise1);
+		awaiter.addTransientSave(promise2);
+		awaiter.addTransientSave(notAPromise1);
+		awaiter.addTransientSave(notAPromise2);
+
+		const resolvedPromises = await awaiter.awaitAllTransientSaves();
+		assert.isTrue(resolvedPromises.some((result) => result === 'one'));
+		assert.isTrue(resolvedPromises.some((result) => result === 'two'));
+		assert.isTrue(resolvedPromises.some((result) => result === 'three'));
+		assert.isTrue(resolvedPromises.some((result) => result === 'four'));
+	});
+
+	it('should throw an error when a save action errors', async() => {
+		const awaiter = new TransientSaveAwaiter();
+		const error = new Error('rip');
+		const errorAction = async() => {
+			throw error;
+		};
+
+		const errorPromise = errorAction();
+		awaiter.addTransientSave(errorPromise);
+		try {
+			await awaiter.awaitAllTransientSaves();
+			assert.fail();
+		} catch (e) {
+			assert.equal(e, error);
+		}
+	});
+});


### PR DESCRIPTION
Related: https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/65

The transient-saving Siren action in the `coa-eval-override` right-hand component is in the component itself, so it isn't mutexed in consistent-eval. Thus, performing the `publish` action before the transient-saving action to finish causes the component to not save correctly.

Changes:
* Add a `_savePromises` array to `consistent-evaluation-page` and await those promises prior to performing any `publish` action
* Modify `transientSaveCoaEvalOverride` to add its `performSirenAction` promise to the promise array

https://rally1.rallydev.com/#/detail/defect/458210498988?fdp=true
