### PR TITLE
Fix COA demo page

### DIFF
--- a/demo/consistent-evaluation-coa-override-page-published.html
+++ b/demo/consistent-evaluation-coa-override-page-published.html
@@ -19,7 +19,7 @@
 
 		<d2l-consistent-evaluation
 			id='consistent-eval'
-			href='data/outcomes-overall-achievement/actor-activity-usage.json'
+			href='data/outcomes-overall-achievement/actor-activity-usage_published.json'
 			return-href-text='Back to Mastery View'
 			return-href='/demo/'
 		></d2l-consistent-evaluation>

--- a/demo/consistent-evaluation-coa-override-page-published.html
+++ b/demo/consistent-evaluation-coa-override-page-published.html
@@ -6,16 +6,13 @@
 		<script type="text/javascript" src="https://s.brightspace.com/lib/moment.js/2.15.2/moment.min.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
-			import '@brightspace-ui/core/components/typography/styles.js';
-			import '@brightspace-ui/core/components/typography/typography.js';
 			import '../components/consistent-evaluation.js';
 		</script>
-		<title>d2l-coa-override-page</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
-	<body class="d2l-typography">
+	<body unresolved>
 		<d2l-demo-page page-title="consistent-evaluation-coa-override-page-published">
 			<d2l-consistent-evaluation
 				id='consistent-eval'

--- a/demo/consistent-evaluation-coa-override-page-published.html
+++ b/demo/consistent-evaluation-coa-override-page-published.html
@@ -16,14 +16,14 @@
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">
-
-		<d2l-consistent-evaluation
-			id='consistent-eval'
-			href='data/outcomes-overall-achievement/actor-activity-usage_published.json'
-			return-href-text='Back to Mastery View'
-			return-href='/demo/'
-		></d2l-consistent-evaluation>
-
+		<d2l-demo-page page-title="consistent-evaluation-coa-override-page-published">
+			<d2l-consistent-evaluation
+				id='consistent-eval'
+				href='data/outcomes-overall-achievement/actor-activity-usage_published.json'
+				return-href-text='Back to Mastery View'
+				return-href='/demo/'
+			></d2l-consistent-evaluation>
+		</d2l-demo-page>
 		<script>
 			const element = document.getElementById('consistent-eval');
 			element.token = async() => { return 'token'; };

--- a/demo/consistent-evaluation-coa-override-page.html
+++ b/demo/consistent-evaluation-coa-override-page.html
@@ -6,16 +6,13 @@
 		<script type="text/javascript" src="https://s.brightspace.com/lib/moment.js/2.15.2/moment.min.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
-			import '@brightspace-ui/core/components/typography/styles.js';
-			import '@brightspace-ui/core/components/typography/typography.js';
 			import '../components/consistent-evaluation.js';
 		</script>
-		<title>d2l-coa-override-page</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
 	</head>
-	<body class="d2l-typography">
+	<body unresolved>
 		<d2l-demo-page page-title="consistent-evaluation-coa-override-page">
 			<d2l-consistent-evaluation
 				id='consistent-eval'

--- a/demo/consistent-evaluation-coa-override-page.html
+++ b/demo/consistent-evaluation-coa-override-page.html
@@ -16,14 +16,14 @@
 		<meta charset="UTF-8">
 	</head>
 	<body class="d2l-typography">
-
-		<d2l-consistent-evaluation
-			id='consistent-eval'
-			href='data/outcomes-overall-achievement/actor-activity-usage.json'
-			return-href-text='Back to Mastery View'
-			return-href='/demo/'
-		></d2l-consistent-evaluation>
-
+		<d2l-demo-page page-title="consistent-evaluation-coa-override-page">
+			<d2l-consistent-evaluation
+				id='consistent-eval'
+				href='data/outcomes-overall-achievement/actor-activity-usage.json'
+				return-href-text='Back to Mastery View'
+				return-href='/demo/'
+			></d2l-consistent-evaluation>
+		</d2l-demo-page>
 		<script>
 			const element = document.getElementById('consistent-eval');
 			element.token = async() => { return 'token'; };

--- a/demo/data/outcomes-overall-achievement/alignment.json
+++ b/demo/data/outcomes-overall-achievement/alignment.json
@@ -1,0 +1,34 @@
+{
+  "class": [
+    "alignment"
+  ],
+  "properties": {
+    "relationshipType": "referenced"
+  },
+  "links": [
+    {
+      "rel": [
+        "collection"
+      ],
+      "href": "data/outcomes-overall-achievement/alignments.json"
+    },
+    {
+      "rel": [
+        "https://outcomes.api.brightspace.com/rels/intent"
+      ],
+      "href": "unused"
+    },
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/outcomes-overall-achievement/alignment.json"
+    },
+    {
+      "rel": [
+        "https://achievements.api.brightspace.com/rels/demonstration"
+      ],
+      "href": "data/outcomes-overall-achievement/demonstrations/dem1006.json"
+    }
+  ]
+}

--- a/demo/data/outcomes-overall-achievement/alignments.json
+++ b/demo/data/outcomes-overall-achievement/alignments.json
@@ -1,0 +1,34 @@
+{
+  "class": [
+    "collection",
+    "alignments"
+  ],
+  "entities": [
+    {
+      "class": [
+        "alignment"
+      ],
+      "rel": [
+        "item"
+      ],
+      "href": "data/outcomes/alignment.json",
+      "properties": {
+        "relationshipType": "referenced"
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "https://41c25168-e162-4d7c-b031-5a30e2dda04a.alignments.api.proddev.d2l/user-activity-usage/6606_2000_3/6613/175"
+    },
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/user-activity-usage"
+      ],
+      "href": "https://41c25168-e162-4d7c-b031-5a30e2dda04a.activities.api.proddev.d2l/activities/6606_2000_3/usages/6613/users/175"
+    }
+  ]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -89,5 +89,12 @@
 				<a href="./consistent-evaluation-coa-override-page.html">consistent-evaluation-coa-override-page</a>
 			</li>
 		</ul>
+
+		<h2>Consistent Evaluation COA Override Page - Published</h2>
+		<ul>
+			<li>
+				<a href="./consistent-evaluation-coa-override-page-published.html">consistent-evaluation-coa-override-page</a>
+			</li>
+		</ul>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -993,7 +993,7 @@
       }
     },
     "@brightspace-ui-labs/multi-select": {
-      "version": "github:BrightspaceUILabs/multi-select#815f50963de105b42364a0028d4330266e901173",
+      "version": "github:BrightspaceUILabs/multi-select#114380b4a6a14f5952310ac484f8fc126c21d193",
       "from": "github:BrightspaceUILabs/multi-select#semver:^4",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -1118,7 +1118,7 @@
       }
     },
     "@d2l/d2l-attachment": {
-      "version": "github:Brightspace/attachment#7b6e48b5d24b607296cacc9aeb2db6733b410599",
+      "version": "github:Brightspace/attachment#61cb005d6db0fc4ccc444d4c4898e5d1d3a2f46a",
       "from": "github:Brightspace/attachment#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -1141,7 +1141,7 @@
       }
     },
     "@d2l/seek-bar": {
-      "version": "github:Brightspace/d2l-seek-bar#14c304b2f99d88f8e9c410307f1ff04a8c848df4",
+      "version": "github:Brightspace/d2l-seek-bar#75523205fd5b301c6b8165cd3e8b101b2588723b",
       "from": "github:Brightspace/d2l-seek-bar#semver:^1",
       "requires": {
         "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
@@ -3899,14 +3899,14 @@
       "dev": true
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#119c5e4921d697f5580172468f8b14592ce7e0e8",
+      "version": "github:BrightspaceHypermediaComponents/activities#c08851274fdac6835111877cbe0ffb19955050b9",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
         "@brightspace-ui-labs/accordion": "^2.0.2",
         "@brightspace-ui-labs/edit-in-place": "^1.0.11",
         "@brightspace-ui-labs/list-item-accumulator": "^1",
-        "@brightspace-ui/core": "^1.102.2",
+        "@brightspace-ui/core": "^1.82.1",
         "@brightspace-ui/intl": "^3.0.1",
         "@d2l/d2l-attachment": "github:Brightspace/attachment#semver:^1",
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -3949,7 +3949,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#312eda188059a201c78af105d7c813894dceccc6",
+      "version": "github:Brightspace/d2l-activity-alignments#e53497a25a23c2b7eb7e7299c5904d10fc9be604",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -3982,10 +3982,11 @@
       }
     },
     "d2l-associations": {
-      "version": "github:BrightspaceHypermediaComponents/associations#a38339bda2397e2df888a8c4ef31f4d0d6b6b88d",
+      "version": "github:BrightspaceHypermediaComponents/associations#fe8f360dd7de0841aa43d8694c00e5ef82e824d5",
       "from": "github:BrightspaceHypermediaComponents/associations#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",
+        "@webcomponents/webcomponentsjs": "^2",
         "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6.30.0",
@@ -4019,7 +4020,7 @@
       }
     },
     "d2l-common": {
-      "version": "github:BrightspaceHypermediaComponents/common#c9f4e4bd3678835c1f01811a432d7ddfd4851c97",
+      "version": "github:BrightspaceHypermediaComponents/common#77e3223755cdd61b4bee00b9fb3463f0dd345c31",
       "from": "github:BrightspaceHypermediaComponents/common#semver:^3",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4035,7 +4036,7 @@
       }
     },
     "d2l-course-image": {
-      "version": "github:Brightspace/course-image#dfd312cf0c3b4c9e2f26a6a1d7085da24ff35a8a",
+      "version": "github:Brightspace/course-image#3b9c30bcdb43e1ebced70290fa9988fb79e5f630",
       "from": "github:Brightspace/course-image#semver:^3",
       "requires": {
         "@brightspace-ui/core": "^1.28.2",
@@ -4098,7 +4099,7 @@
       }
     },
     "d2l-facet-filter-sort": {
-      "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
+      "version": "github:BrightspaceUI/facet-filter-sort#ecb32711ae3b37fc0426e5fce7ef60c2f794a219",
       "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -4111,7 +4112,7 @@
       }
     },
     "d2l-fetch": {
-      "version": "github:Brightspace/d2l-fetch#09b1435d43d67e1a27d2a8663524b4840adedb6f",
+      "version": "github:Brightspace/d2l-fetch#d2b14d7bfad9050fdf4eea6f42ec91f0b3e18de4",
       "from": "github:Brightspace/d2l-fetch#semver:^2"
     },
     "d2l-fetch-auth": {
@@ -4182,7 +4183,7 @@
       }
     },
     "d2l-localize-behavior": {
-      "version": "github:BrightspaceUI/localize-behavior#1110bbcc7b8fe6237167a6020d3a5d3ff4e1b1c9",
+      "version": "github:BrightspaceUI/localize-behavior#ff9514e84470665348ccbb8584c32b5f51abf13b",
       "from": "github:BrightspaceUI/localize-behavior#semver:^2",
       "requires": {
         "@brightspace-ui/intl": "^3",
@@ -4201,7 +4202,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#c5e0d2ef38ad7b38996256a620145ab51873026a",
+      "version": "github:BrightspaceUI/navigation#28ea93cc4a27cf96a0c82ab66fb62cfa045847a2",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4231,7 +4232,7 @@
       "from": "github:Brightspace/organization-hm-behavior#semver:^3"
     },
     "d2l-organizations": {
-      "version": "github:BrightspaceHypermediaComponents/organizations#f673b4e63204081610b389d39456cec7fc854762",
+      "version": "github:BrightspaceHypermediaComponents/organizations#b214e9e2dd4a75d74521387050277a984fa023da",
       "from": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4257,7 +4258,7 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#263d93f8607104a9e0dd08280d5ecff684d01515",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#25d21c45b58ef6cabc452c646c8739c0f57cf3aa",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4270,7 +4271,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#f7bc1dae15b42de82135c5a94ec5dec215ff1ccd",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#1f59531cf802fe7404b435ea68aeadf531e4d932",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1.98.0",
@@ -4278,7 +4279,6 @@
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
         "lit-element": "^2.3.1",
-        "lit-html": "^1.3.0",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
@@ -4319,7 +4319,7 @@
       }
     },
     "d2l-progress": {
-      "version": "github:BrightspaceUI/progress#0c039095a01a1aeee11425463cf3b2c3dad125bb",
+      "version": "github:BrightspaceUI/progress#709b7bcb4591339d0478e31fff083108efcbdf9b",
       "from": "github:BrightspaceUI/progress#semver:^1",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4334,7 +4334,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#ae1d162dc591187de38848c1bafb16e94e925857",
+      "version": "github:Brightspace/d2l-rubric#a2c53342d8b7d06f3a444581aac2c81d6fb09f45",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
@@ -4384,13 +4384,12 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#efb95a0d9183ecd2c1fc994213e9faafdfb10582",
+      "version": "github:BrightspaceHypermediaComponents/sequences#2638e8341dcb13688a157c0a8dcf9c1799fe480a",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",
         "@brightspace-ui-labs/media-player": "^1",
         "@brightspace-ui/core": "^1",
-        "@brightspace-ui/intl": "^3.1.0",
         "@d2l/audio": "github:Brightspace/d2l-audio#semver:^3",
         "@d2l/video": "github:Brightspace/d2l-video#semver:^2",
         "@polymer/iron-a11y-announcer": "^3.1.0",
@@ -4428,7 +4427,7 @@
       }
     },
     "d2l-table": {
-      "version": "github:BrightspaceUI/table#72456b80ad7dfcacf2bd47f483c8044f7d444db0",
+      "version": "github:BrightspaceUI/table#56a7628a17a95a08983164f7331e5f6c2d9c2858",
       "from": "github:BrightspaceUI/table#semver:^2",
       "requires": {
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -4475,7 +4474,7 @@
       }
     },
     "d2l-users": {
-      "version": "github:BrightspaceHypermediaComponents/users#14a55f2d0a451f4b695e149a146c8c2662d2d13e",
+      "version": "github:BrightspaceHypermediaComponents/users#727516f1fe8618d84dccccb7d07f85137fd115d9",
       "from": "github:BrightspaceHypermediaComponents/users#semver:^2",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -10479,7 +10478,7 @@
       "dev": true
     },
     "siren-entity": {
-      "version": "github:BrightspaceHypermediaComponents/siren-entity#461518bd3f9b40b67ba980afdf66c3f4bbeedf21",
+      "version": "github:BrightspaceHypermediaComponents/siren-entity#b5dea3354ab63d8e92f7f9a3b686446897b48e56",
       "from": "github:BrightspaceHypermediaComponents/siren-entity#semver:^1",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -10492,7 +10491,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#ac36ee8c0c4296ec1bebf94201b8df04b9a11d1c",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#9c672ccde7b6cbd45c2f476d04e890d13acbe029",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
This focuses on the `consistent-evaluation-coa-override-page` demo page.

Changes:
* Add necessary data files for ConsistentEvaluationController to correctly get its data for `consistent-evaluation-coa-override-page`
* Remove `d2l-demo-snippet`, since it doesn't work well with the `position: absolute` property of `d2l-template-primary-secondary`
* Add another demo page for a published COA evaluation

This is what the demo page will look like:
![image](https://user-images.githubusercontent.com/59580265/101645951-f0d98700-3a04-11eb-942f-2e578a88f32f.png)
