### PR TITLE
reduce padding to ensure one line for all languages

### DIFF
--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -49,7 +49,6 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 				display: none;
 			}
 			.d2l-iterator-space {
-				display: flex;
 				margin-left: 2.5rem;
 				margin-right: 2.5rem;
 			}

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -49,8 +49,8 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 				display: none;
 			}
 			.d2l-iterator-text {
-				padding-left: 4rem;
-				padding-right: 4rem;
+				padding-left: 2.5rem;
+				padding-right: 2.5rem;
 			}
 			.d2l-heading-3 {
 				padding-top: 0.25rem;

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -77,12 +77,10 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 				.d2l-iterator-space {
 					margin-left: 0;
 					margin-right: 0;
+					min-width: 1rem;
 				}
 				.d2l-iterator-text {
 					display: none;
-				}
-				.d2l-iterator-space {
-					min-width: 1rem;
 				}
 				.d2l-short-back {
 					display: inline-block;

--- a/components/header/consistent-evaluation-nav-bar.js
+++ b/components/header/consistent-evaluation-nav-bar.js
@@ -48,9 +48,10 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 			.d2l-short-back {
 				display: none;
 			}
-			.d2l-iterator-text {
-				padding-left: 2.5rem;
-				padding-right: 2.5rem;
+			.d2l-iterator-space {
+				display: flex;
+				margin-left: 2.5rem;
+				margin-right: 2.5rem;
 			}
 			.d2l-heading-3 {
 				padding-top: 0.25rem;
@@ -67,13 +68,17 @@ class ConsistentEvaluationNavBar extends LocalizeConsistentEvaluation(LitElement
 			}
 
 			@media (max-width: 929px) {
-				.d2l-iterator-text {
-					padding-left: 1rem;
-					padding-right: 1rem;
+				.d2l-iterator-space {
+					margin-left: 1rem;
+					margin-right: 1rem;
 				}
 			}
 
 			@media (max-width: 556px) {
+				.d2l-iterator-space {
+					margin-left: 0;
+					margin-right: 0;
+				}
 				.d2l-iterator-text {
 					display: none;
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3899,7 +3899,7 @@
       "dev": true
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#9fac9d3b40d1ca37c0fccd47cf7d175030a650c4",
+      "version": "github:BrightspaceHypermediaComponents/activities#119c5e4921d697f5580172468f8b14592ce7e0e8",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
@@ -3941,7 +3941,6 @@
         "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",
         "del": "^6.0.0",
         "fastdom": "^1.0.8",
-        "lit-element": "^2",
         "lit-html": "^1.1.2",
         "merge-stream": "^1.0.1",
         "mobx": "^5.15.2",
@@ -4258,7 +4257,7 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#a1c8fee054f1fad6350578ef070cbf9cf3bc5a8d",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#263d93f8607104a9e0dd08280d5ecff684d01515",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4271,7 +4270,7 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#138ae38d555e28ead10ced6b4707b977863e8325",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#f7bc1dae15b42de82135c5a94ec5dec215ff1ccd",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1.98.0",
@@ -4335,7 +4334,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#affbf9b2f7ca8fc117da2bad9b2ca1fd0e36c1ad",
+      "version": "github:Brightspace/d2l-rubric#ae1d162dc591187de38848c1bafb16e94e925857",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
@@ -4385,7 +4384,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#0485718142dabb8aca5ffabbe9a4c58ac8f51e73",
+      "version": "github:BrightspaceHypermediaComponents/sequences#efb95a0d9183ecd2c1fc994213e9faafdfb10582",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",
@@ -10493,7 +10492,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#56077b1fb0e02dbb88d5aeb8afb5fff5e8f0c7d5",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#ac36ee8c0c4296ec1bebf94201b8df04b9a11d1c",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",


### PR DESCRIPTION
[DE41679](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fdefect%2F463461237476&fdp=true?fdp=true): Translations - The text for User x of y in the navbar is wrapping with Japanese and Arabic languages

`2.5rem` fixes this for sufficiently large class sizes (665 of 665):
![japanese](https://user-images.githubusercontent.com/11618509/101947175-0514b400-3bbe-11eb-8c63-7d4e7bc2d004.png)
