### PR TITLE
Fix truncating bug in grading rubric dropdown

### DIFF
--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -43,6 +43,13 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(LitElement
 				font-weight: 600;
 				margin-bottom: 0.4rem;
 			}
+			.d2l-input-select {
+				max-width: 12rem;
+				overflow: hidden;
+				overflow-wrap: break-word;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 		`];
 	}
 
@@ -130,13 +137,21 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(LitElement
 		}
 		return html`
 			<h2 class="d2l-label-text">${this.localize('gradingRubric')}</h2>
-			<select class="d2l-input-select d2l-truncate d2l-consistent-evaluation-active-scoring-rubric" aria-label=${this.localize('activeGradingRubric')} @change=${this._onActiveScoringRubricChange}>
+			<select class="d2l-input-select d2l-consistent-evaluation-active-scoring-rubric" aria-label=${this.localize('activeGradingRubric')} @change=${this._onActiveScoringRubricChange}>
 				<option label=${this.localize('noActiveGradingRubric')} ?selected=${!this.activeScoringRubric} value=null></option>
 				${scoringRubrics.map(rubric => html`
-						<option value="${rubric.rubricId}" label=${rubric.rubricTitle} class="select-option"></option>
+						<option value="${rubric.rubricId}" label=${this._truncateRubricTitle(rubric.rubricTitle)} class="select-option"></option>
 				`)}
 			</select>
 		`;
+	}
+
+	_truncateRubricTitle(rubricTitle) {
+		const maxTitleLength = 50;
+		if (rubricTitle.length <= maxTitleLength) {
+			return rubricTitle;
+		}
+		return  `${rubricTitle.substring(0, maxTitleLength)}…`;
 	}
 
 	_getSummaryText() {

--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -43,8 +43,8 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(LitElement
 				font-weight: 600;
 				margin-bottom: 0.4rem;
 			}
-			.d2l-input-select {
-				max-width: 12rem;
+			.d2l-consistent-evaluation-active-scoring-rubric {
+				max-width: 100%;
 				overflow: hidden;
 				overflow-wrap: break-word;
 				text-overflow: ellipsis;
@@ -147,7 +147,7 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(LitElement
 	}
 
 	_truncateRubricTitle(rubricTitle) {
-		const maxTitleLength = 50;
+		const maxTitleLength = 60;
 		return (rubricTitle.length <= maxTitleLength) ? rubricTitle : `${rubricTitle.substring(0, maxTitleLength)}…`;
 	}
 

--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -148,10 +148,7 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(LitElement
 
 	_truncateRubricTitle(rubricTitle) {
 		const maxTitleLength = 50;
-		if (rubricTitle.length <= maxTitleLength) {
-			return rubricTitle;
-		}
-		return  `${rubricTitle.substring(0, maxTitleLength)}…`;
+		return (rubricTitle.length <= maxTitleLength) ? rubricTitle : `${rubricTitle.substring(0, maxTitleLength)}…`;
 	}
 
 	_getSummaryText() {


### PR DESCRIPTION
Talked to Dan and he liked the look of truncating the contents of the grading rubric like how we did it for the file-context-dropdown

![image](https://user-images.githubusercontent.com/32204301/102533592-9fb83b80-4073-11eb-841c-e20228423ea4.png)
