### PR TITLE
DE42030 Allow a default grade of null.

### DIFF
--- a/components/right-panel/consistent-evaluation-grade-result.js
+++ b/components/right-panel/consistent-evaluation-grade-result.js
@@ -119,9 +119,7 @@ export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluatio
 		const scoreOutOf = this.grade.getScoreOutOf();
 
 		// handle when grade is not yet initialized on the server
-		if (gradeType === GradeType.Number && score === null) {
-			score = 0;
-		} else if (gradeType === GradeType.Letter && score === null) {
+		if (gradeType === GradeType.Letter && score === null) {
 			score = '';
 		}
 		this._setGradeSummaryInfo(gradeType, score, scoreOutOf);


### PR DESCRIPTION
When the grade is null, don't change it to 0. 
Note: this ticket won't have an effect until https://github.com/Brightspace/lms/pull/5582 is merged in as we currently never return null for a grade