### PR TITLE
DE42053/mbosilj round score.

### DIFF
--- a/components/right-panel/consistent-evaluation-grade-result.js
+++ b/components/right-panel/consistent-evaluation-grade-result.js
@@ -113,6 +113,12 @@ export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluatio
 		this._gradeSummaryInfo = summary;
 	}
 
+	_roundScore(score) {
+		const numDecimals = 2;
+		const dfactor = Math.pow(10, numDecimals);
+		return Math.round(score * dfactor) / dfactor;
+	}
+
 	render() {
 		const gradeType = this.grade.getScoreType();
 		let score = this.grade.getScore();
@@ -122,6 +128,11 @@ export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluatio
 		if (gradeType === GradeType.Letter && score === null) {
 			score = '';
 		}
+
+		if (gradeType === GradeType.Number && score !== null) {
+			score = this._roundScore(score);
+		}
+
 		this._setGradeSummaryInfo(gradeType, score, scoreOutOf);
 
 		return html`


### PR DESCRIPTION
Note: If the user updates the grade component then clicks away from it, the grade component will re-render and display the grade to 2 decimal places. 
Also talked with Megan S and decided to do regular rounding (round 0.5 up), not bankers (round 0.5 to nearest even number) to 2 decimal places

![image](https://user-images.githubusercontent.com/40582786/105223970-86028c00-5b2a-11eb-963f-43a962f32949.png)