### PR TITLE
122595 Fix to let users update/publish twice.

### DIFF
--- a/components/consistent-evaluation-dialogs.js
+++ b/components/consistent-evaluation-dialogs.js
@@ -92,16 +92,18 @@ export class ConsistentEvaluationDialogs extends LocalizeConsistentEvaluation(Li
 		this._publishUnscoredCriteriaDialogOpened = false;
 		if (e.detail.action !== DIALOG_ACTION_CONTINUE_GRADING) {
 			this._firePublishEvaluationEvent();
+		} else {
+			this._fireDialogClosedEvent();
 		}
-		this._fireDialogClosedEvent();
 	}
 
 	async _onUpdateUnscoredCriteriaDialogClosed(e) {
 		this._updateUnscoredCriteriaDialogOpened = false;
 		if (e.detail.action !== DIALOG_ACTION_CONTINUE_GRADING) {
 			this._fireUpdateEvaluationEvent();
+		} else {
+			this._fireDialogClosedEvent();
 		}
-		this._fireDialogClosedEvent();
 	}
 
 	async _fireUpdateEvaluationEvent() {

--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -491,6 +491,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			composed: true,
 			bubbles: true
 		}));
+		this._isUpdateClicked = false;
 
 		await this._transientSaveAwaiter.awaitAllTransientSaves();
 		await this._mutex.dispatch(
@@ -512,6 +513,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 			composed: true,
 			bubbles: true
 		}));
+		this._isPublishClicked = false;
 
 		await this._transientSaveAwaiter.awaitAllTransientSaves();
 		await this._mutex.dispatch(


### PR DESCRIPTION
My previous change seems to not allow users to update/publish twice in a row (because it didn't reset `isUpdateClicked`/`isPublishClicked` to false after an update). This fixes that!