### PR TITLE
US122594/mbosilj use "incomplete" class.

### DIFF
--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -284,7 +284,7 @@ export class ConsistentEvaluationHrefController {
 						const rubricOutOf = rubricEntity.entity.properties.outOf;
 						const rubricScoringMethod = rubricEntity.entity.properties.scoringMethod;
 
-						const hasUnscoredCriteria = assessmentEntity.entity.properties.hasUnscoredCriteria;
+						const hasUnscoredCriteria = assessmentEntity.entity.hasClass('incomplete');
 
 						let assessorDisplayName = null;
 						const assessorUserHref = this._getHref(assessmentEntity.entity, assessorUserRel);

--- a/test/ConsistentEvaluationHrefController.test.js
+++ b/test/ConsistentEvaluationHrefController.test.js
@@ -205,15 +205,11 @@ describe('ConsistentEvaluationHrefController', () => {
 			const expectedRubricHrefTwo = 'the_rubric_href_to_find_two';
 			const assessmentEntityOne = {
 				name:'entity1',
-				properties: {
-					hasUnscoredCriteria: false
-				}
+				hasClass: () => true
 			};
 			const assessmentEntityTwo = {
 				name:'entity2',
-				properties: {
-					hasUnscoredCriteria: true
-				}
+				hasClass: () => false
 			};
 			const rubricEntityOne = {
 				properties: {
@@ -288,8 +284,8 @@ describe('ConsistentEvaluationHrefController', () => {
 			assert.equal(rubricInfos[1].rubricOutOf, rubricEntityTwo.properties.outOf);
 			assert.equal(rubricInfos[1].rubricScoringMethod, rubricEntityTwo.properties.scoringMethod);
 
-			assert.equal(rubricInfos[0].hasUnscoredCriteria, assessmentEntityOne.properties.hasUnscoredCriteria);
-			assert.equal(rubricInfos[1].hasUnscoredCriteria, assessmentEntityTwo.properties.hasUnscoredCriteria);
+			assert.equal(rubricInfos[0].hasUnscoredCriteria, assessmentEntityOne.hasClass('incomplete'));
+			assert.equal(rubricInfos[1].hasUnscoredCriteria, assessmentEntityTwo.hasClass('incomplete'));
 		});
 	});
 });


### PR DESCRIPTION
Instead of adding "hasUnscoredCriteria" to the api use whether the assessment entity has "complete" or "incomplete" class to determine whether the rubrics have unscored assessments
Note: Currently "incomplete" and "complete" are returned on a rubric incorrectly as noted in [this defect](https://rally1.rallydev.com/#/42960320374d/dashboard?Iteration=u&Name=&Project=%2Fproject%2F42960320374&Release=u&cpoid=42960320374&detail=%2Fdefect%2F489745544288&rankTo=BOTTOM&typeDef=7362609627) . There will be a partner PR in the backend to fix this that will also remove "hasUnscoredCriteria" from the backend.