### PR TITLE
Add user-profile-card to CE

### DIFF
--- a/components/header/consistent-evaluation-user-profile-card.js
+++ b/components/header/consistent-evaluation-user-profile-card.js
@@ -1,0 +1,41 @@
+import '@brightspace-ui-labs/user-profile-card/user-profile-card.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+
+import { html, LitElement } from 'lit-element';
+import { LocalizeConsistentEvaluation } from '../../lang/localize-consistent-evaluation.js';
+
+export class ConsistentEvaluationUserProfileCard extends LocalizeConsistentEvaluation(LitElement) {
+
+	static get properties() {
+		return {
+			displayName: {
+				attribute: 'display-name',
+				type: String
+			},
+			tagline: {
+				attribute: 'tag-line',
+				type: String
+			}
+		};
+	}
+
+	dispatchMouseLeaveEvent() {
+		this.dispatchEvent(new CustomEvent('d2l-consistent-eval-profile-card-mouse-leave', {
+			composed: true,
+			bubbles: true,
+		}));
+	}
+
+	render() {
+		return html`
+		<d2l-labs-user-profile-card
+			@mouseleave=${this.dispatchMouseLeaveEvent}
+			tagline=${this.tagline}>
+			<img slot="illustration" src="" width="116px" height="116px">
+			${this.displayName}
+		</d2l-labs-user-profile-card>
+		`;
+	}
+}
+
+customElements.define('d2l-consistent-evaluation-user-profile-card', ConsistentEvaluationUserProfileCard);

--- a/components/header/consistent-evaluation-user-profile-card.js
+++ b/components/header/consistent-evaluation-user-profile-card.js
@@ -13,7 +13,6 @@ export class ConsistentEvaluationUserProfileCard extends LocalizeConsistentEvalu
 				type: String
 			},
 			tagline: {
-				attribute: 'tag-line',
 				type: String
 			}
 		};
@@ -31,7 +30,7 @@ export class ConsistentEvaluationUserProfileCard extends LocalizeConsistentEvalu
 		<d2l-labs-user-profile-card
 			@mouseleave=${this.dispatchMouseLeaveEvent}
 			tagline=${this.tagline}>
-			<img slot="illustration" src="" width="116px" height="116px">
+			<img slot="illustration" src="">
 			${this.displayName}
 		</d2l-labs-user-profile-card>
 		`;

--- a/components/header/d2l-consistent-evaluation-lcb-user-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-user-context.js
@@ -1,4 +1,5 @@
 import 'd2l-users/components/d2l-profile-image.js';
+import './consistent-evaluation-user-profile-card.js';
 import { bodyCompactStyles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
@@ -22,6 +23,10 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 			_displayName: {
 				attribute: false,
 				type: String
+			},
+			_showProfileCard: {
+				attribute: false,
+				type: Boolean
 			}
 		};
 	}
@@ -54,6 +59,16 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 			}
 			h2:focus {
 				outline: none;
+			}
+			.d2l-user-context-container {
+				align-items: center;
+				display: flex;
+			}
+			.d2l-consistent-evaluation-user-profile-card-container {
+				top: 3rem;
+				z-index: 1;
+				background: white;
+				position: absolute;
 			}
 		`];
 	}
@@ -100,11 +115,40 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 		}
 	}
 
+	_renderProfileCard() {
+		return this._showProfileCard ?
+			html`
+			<d2l-consistent-evaluation-user-profile-card
+				display-name=${ifDefined(this._displayName)}
+				tag-line="This is a tag-line that will come from the API?"
+				@d2l-consistent-eval-profile-card-mouse-leave=${this._toggleOffProfileCard}>
+			</d2l-consistent-evaluation-user-profile-card>
+			` :
+			html``;
+	}
+
+	_toggleOnProfileCard() {
+		this._showProfileCard = true;
+	}
+
+	_toggleOffProfileCard() {
+		this._showProfileCard = false;
+	}
+
 	render() {
 		return html`
+		<div class="d2l-user-context-container"
+			@click=${this._toggleOnProfileCard}
+			@mouseover=${this._toggleOnProfileCard}>
+
 			${this._renderProfileImage()}
 			<h2 tabindex="0" class="d2l-body-compact d2l-consistent-evaluation-lcb-user-name">${ifDefined(this._displayName)}</h2>
 			${this._getExemptText()}
+		</div>
+
+		<div class="d2l-consistent-evaluation-user-profile-card-container">
+			${this._renderProfileCard()}
+		</div>
 		`;
 	}
 }

--- a/components/header/d2l-consistent-evaluation-lcb-user-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-user-context.js
@@ -65,10 +65,10 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 				display: flex;
 			}
 			.d2l-consistent-evaluation-user-profile-card-container {
-				top: 3rem;
-				z-index: 1;
 				background: white;
 				position: absolute;
+				top: 3rem;
+				z-index: 1;
 			}
 		`];
 	}

--- a/components/header/d2l-consistent-evaluation-lcb-user-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-user-context.js
@@ -57,7 +57,7 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 				margin-left: 0;
 				margin-right: 0.5rem;
 			}
-			h2:focus {
+			.d2l-user-context-container:focus {
 				outline: none;
 			}
 			.d2l-user-context-container {
@@ -77,6 +77,16 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 		super();
 
 		this._setEntityType(UserEntity);
+	}
+
+	firstUpdated() {
+		const userContextContainer = this.shadowRoot.querySelector('.d2l-user-context-container');
+		userContextContainer.addEventListener('focusin', () => {
+			this._toggleOnProfileCard();
+		});
+		userContextContainer.addEventListener('focusout', () => {
+			this._toggleOffProfileCard();
+		});
 	}
 
 	set _entity(entity) {
@@ -120,7 +130,7 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 			html`
 			<d2l-consistent-evaluation-user-profile-card
 				display-name=${ifDefined(this._displayName)}
-				tag-line="This is a tag-line that will come from the API?"
+				tagline="This is a tag-line that will come from the API?"
 				@d2l-consistent-eval-profile-card-mouse-leave=${this._toggleOffProfileCard}>
 			</d2l-consistent-evaluation-user-profile-card>
 			` :
@@ -138,11 +148,12 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 	render() {
 		return html`
 		<div class="d2l-user-context-container"
-			@click=${this._toggleOnProfileCard}
+			tabindex="0"
+			aria-label=${ifDefined(this._displayName)}
 			@mouseover=${this._toggleOnProfileCard}>
 
 			${this._renderProfileImage()}
-			<h2 tabindex="0" class="d2l-body-compact d2l-consistent-evaluation-lcb-user-name">${ifDefined(this._displayName)}</h2>
+			<h2 class="d2l-body-compact d2l-consistent-evaluation-lcb-user-name">${ifDefined(this._displayName)}</h2>
 			${this._getExemptText()}
 		</div>
 

--- a/demo/consistent-evaluation-user-profile-card.html
+++ b/demo/consistent-evaluation-user-profile-card.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en-us">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../components/header/consistent-evaluation-user-profile-card.js';
+		</script>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="d2l-consistent-evaluation-user-profile-card">
+
+            <d2l-demo-snippet>
+				<d2l-consistent-evaluation-user-profile-card
+					display-name="Team Nimbus"
+					tag-line="This is a tag-line that I put">
+				</d2l-consistent-evaluation-user-profile-card>
+            </d2l-demo-snippet>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,5 +115,12 @@
 				<a href="./consistent-evaluation-tii-similarity.html">consistent-evaluation-tii-similarity</a>
 			</li>
 		</ul>
+
+		<h2>Consistent Evaluation User Profile Card</h2>
+		<ul>
+			<li>
+				<a href="./consistent-evaluation-user-profile-card.html">consistent-evaluation-user-profile-card</a>
+			</li>
+		</ul>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -947,29 +947,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@brightspace-hmc/foundation-components": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-components#8ccc0e5a980fa2d9c4120ddde945e8460ef0873d",
-      "from": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
-      "requires": {
-        "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
-        "@brightspace-ui-labs/list-item-accumulator": "^1",
-        "@brightspace-ui/core": "^1",
-        "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",
-        "d2l-course-image": "github:Brightspace/course-image#semver:^3",
-        "lit-element": "^2",
-        "lit-html": "^1.3.0",
-        "siren-parser": "^8.2.0"
-      }
-    },
-    "@brightspace-hmc/foundation-engine": {
-      "version": "github:BrightspaceHypermediaComponents/foundation-engine#49b62237c7962de41d6fbf0248f322b6983b2dd9",
-      "from": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
-      "requires": {
-        "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-        "lit-html": "^1.3.0",
-        "siren-parser": "^8.2.0"
-      }
-    },
     "@brightspace-ui-labs/accordion": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/accordion/-/accordion-2.4.2.tgz",
@@ -988,20 +965,6 @@
       "integrity": "sha512-zxcK1vdtVIgpDhURGCM5fLf3Y9PWG9Ettu/BC6hucjrcKY674sWTellLcd5V+2PPGzZ4BTpBRaH8Ds8ygE8AFw==",
       "requires": {
         "@brightspace-ui/core": "^1",
-        "lit-element": "^2"
-      }
-    },
-    "@brightspace-ui-labs/facet-filter-sort": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/facet-filter-sort/-/facet-filter-sort-4.1.0.tgz",
-      "integrity": "sha512-8dlqmjK3ybzFG9JWwXH48MjDkkMA2oQPMC53iJnVZvBcWBtuTkGVKuc6DSzmBISbpwceruwradpTE624S2jGfg==",
-      "requires": {
-        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
-        "@brightspace-ui/core": "^1",
-        "@polymer/polymer": "^3",
-        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
         "lit-element": "^2"
       }
     },
@@ -1048,6 +1011,15 @@
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+      }
+    },
+    "@brightspace-ui-labs/user-profile-card": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui-labs/user-profile-card/-/user-profile-card-0.1.1.tgz",
+      "integrity": "sha512-INSJclNgSfCnHTd34hY1n423WEjoVCuyhjWt883xo0El0YerYCH7IU5BqRcP22DblzqOcPLI3//H0JoY70PaOQ==",
+      "requires": {
+        "@brightspace-ui/core": "^1",
+        "lit-element": "^2"
       }
     },
     "@brightspace-ui/core": {
@@ -1109,7 +1081,7 @@
       }
     },
     "@d2l/d2l-attachment": {
-      "version": "github:Brightspace/attachment#705ea93d12e0a7f91f60614068e0fd5fddcafdd4",
+      "version": "github:Brightspace/attachment#7b6e48b5d24b607296cacc9aeb2db6733b410599",
       "from": "github:Brightspace/attachment#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -3764,16 +3736,14 @@
       "dev": true
     },
     "d2l-activities": {
-      "version": "github:BrightspaceHypermediaComponents/activities#4d20c0997b8ea5bd80760c8ff29d2d877f824fcc",
+      "version": "github:BrightspaceHypermediaComponents/activities#119c5e4921d697f5580172468f8b14592ce7e0e8",
       "from": "github:BrightspaceHypermediaComponents/activities#semver:^3",
       "requires": {
         "@adobe/lit-mobx": "^0.0.x",
-        "@brightspace-hmc/foundation-components": "github:BrightspaceHypermediaComponents/foundation-components#semver:^0",
         "@brightspace-ui-labs/accordion": "^2.0.2",
         "@brightspace-ui-labs/edit-in-place": "^1.0.11",
         "@brightspace-ui-labs/list-item-accumulator": "^1",
         "@brightspace-ui/core": "^1.102.2",
-        "@brightspace-ui/htmleditor": "^1",
         "@brightspace-ui/intl": "^3.0.1",
         "@d2l/d2l-attachment": "github:Brightspace/attachment#semver:^1",
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -3794,7 +3764,6 @@
         "d2l-link": "github:BrightspaceUI/link#semver:^5",
         "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",
         "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-        "d2l-navigation": "github:BrightspaceUI/navigation#semver:^4",
         "d2l-offscreen": "github:BrightspaceUI/offscreen#semver:^4",
         "d2l-organizations": "github:BrightspaceHypermediaComponents/organizations#semver:^5",
         "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
@@ -3809,7 +3778,6 @@
         "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",
         "del": "^6.0.0",
         "fastdom": "^1.0.8",
-        "lit-element": "^2",
         "lit-html": "^1.1.2",
         "merge-stream": "^1.0.1",
         "mobx": "^5.15.2",
@@ -3818,7 +3786,7 @@
       }
     },
     "d2l-activity-alignments": {
-      "version": "github:Brightspace/d2l-activity-alignments#afb3428f7fee27cdc1d47b42b949bd97d24a52ff",
+      "version": "github:Brightspace/d2l-activity-alignments#312eda188059a201c78af105d7c813894dceccc6",
       "from": "github:Brightspace/d2l-activity-alignments#semver:^2",
       "requires": {
         "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
@@ -3888,11 +3856,11 @@
       }
     },
     "d2l-common": {
-      "version": "github:BrightspaceHypermediaComponents/common#eae7b1c61dc2b69cd13799a636e029550edc838d",
+      "version": "github:BrightspaceHypermediaComponents/common#c9f4e4bd3678835c1f01811a432d7ddfd4851c97",
       "from": "github:BrightspaceHypermediaComponents/common#semver:^3",
       "requires": {
-        "@brightspace-ui-labs/facet-filter-sort": "^4",
         "@polymer/polymer": "^3.0.0",
+        "d2l-facet-filter-sort": "github:BrightspaceUI/facet-filter-sort#semver:^3",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1"
       }
     },
@@ -3966,6 +3934,19 @@
         "@polymer/polymer": "^3"
       }
     },
+    "d2l-facet-filter-sort": {
+      "version": "github:BrightspaceUI/facet-filter-sort#8b8d50298410d5d2c0eaf07b6b5e1265114a1628",
+      "from": "github:BrightspaceUI/facet-filter-sort#semver:^3",
+      "requires": {
+        "@brightspace-ui-labs/multi-select": "github:BrightspaceUILabs/multi-select#semver:^4",
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3",
+        "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
+        "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "lit-element": "^2"
+      }
+    },
     "d2l-fetch": {
       "version": "github:Brightspace/d2l-fetch#09b1435d43d67e1a27d2a8663524b4840adedb6f",
       "from": "github:Brightspace/d2l-fetch#semver:^2"
@@ -4012,12 +3993,13 @@
       }
     },
     "d2l-inputs": {
-      "version": "github:BrightspaceUI/inputs#07070c64aa02ebbc73b473ca0b0eeb4a3ecd3215",
+      "version": "github:BrightspaceUI/inputs#d45f33366162de087317665c9e09c776be9f3aaf",
       "from": "github:BrightspaceUI/inputs#semver:^2",
       "requires": {
-        "@brightspace-ui/core": "^1.113.5",
+        "@brightspace-ui/core": "^1.19.1",
         "@polymer/polymer": "^3.0.0",
-        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+        "fastdom": "^1"
       }
     },
     "d2l-link": {
@@ -4056,7 +4038,7 @@
       }
     },
     "d2l-navigation": {
-      "version": "github:BrightspaceUI/navigation#d59066dce1f1b7fd08834a2788c56e9b0389041b",
+      "version": "github:BrightspaceUI/navigation#c5e0d2ef38ad7b38996256a620145ab51873026a",
       "from": "github:BrightspaceUI/navigation#semver:^4",
       "requires": {
         "@polymer/polymer": "^3.0.0",
@@ -4112,7 +4094,7 @@
       }
     },
     "d2l-outcomes-level-of-achievements": {
-      "version": "github:Brightspace/outcomes-level-of-achievement-ui#1a0fe975c9bad6474d0e8b4499438036650559c7",
+      "version": "github:Brightspace/outcomes-level-of-achievement-ui#263d93f8607104a9e0dd08280d5ecff684d01515",
       "from": "github:Brightspace/outcomes-level-of-achievement-ui#semver:^3",
       "requires": {
         "@brightspace-ui/core": "^1",
@@ -4125,17 +4107,15 @@
       }
     },
     "d2l-outcomes-overall-achievement": {
-      "version": "github:Brightspace/d2l-outcomes-overall-achievement#ad9cc3c3e879eae3f74fd447734481d956118925",
+      "version": "github:Brightspace/d2l-outcomes-overall-achievement#f7bc1dae15b42de82135c5a94ec5dec215ff1ccd",
       "from": "github:Brightspace/d2l-outcomes-overall-achievement#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1.98.0",
         "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
         "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
         "d2l-table": "github:BrightspaceUI/table#semver:^2",
-        "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",
         "lit-element": "^2.3.1",
         "lit-html": "^1.3.0",
-        "lodash-es": "^4.17.20",
         "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
       }
     },
@@ -4191,11 +4171,11 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#c41cbe32db7efba377d10e8d61ce59d7577a79ed",
+      "version": "github:Brightspace/d2l-rubric#ae1d162dc591187de38848c1bafb16e94e925857",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",
-        "@brightspace-ui/core": "^1.113.5",
+        "@brightspace-ui/core": "^1.30.1",
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/iron-overlay-behavior": "^3.0.2",
         "@polymer/iron-resizable-behavior": "^3.0.0",
@@ -4241,7 +4221,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#e181ab35f60660d8f5945f2c42558f12da6548fa",
+      "version": "github:BrightspaceHypermediaComponents/sequences#efb95a0d9183ecd2c1fc994213e9faafdfb10582",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.3.0",
@@ -4298,7 +4278,7 @@
       }
     },
     "d2l-telemetry-browser-client": {
-      "version": "github:Brightspace/d2l-telemetry-browser-client#5e636c6d1e149ebe0e5b0e2a214cb18b9cc4543c",
+      "version": "github:Brightspace/d2l-telemetry-browser-client#8db1cec35d6cf40eb6c345158c2bfbfdc8ea417e",
       "from": "github:Brightspace/d2l-telemetry-browser-client#semver:^1"
     },
     "d2l-time-picker": {
@@ -8100,11 +8080,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
-    "lodash-es": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -10337,7 +10312,7 @@
       "integrity": "sha512-m9XDrKoXYPN1l5wDi9PdZKzSd9CDvvW6OaeXhe2wYR+DafffFSb9wklSt+ETBgW+pq6bHnYT7MxARirLihdZPQ=="
     },
     "siren-sdk": {
-      "version": "github:BrightspaceHypermediaComponents/siren-sdk#9f5bfec89c94472741a3a947377fe1d857311475",
+      "version": "github:BrightspaceHypermediaComponents/siren-sdk#ac36ee8c0c4296ec1bebf94201b8df04b9a11d1c",
       "from": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1",
       "requires": {
         "@brightspace-ui/core": "^1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@brightspace-ui-labs/grade-result": "^1.0.5",
+    "@brightspace-ui-labs/user-profile-card": "^0.1.1",
     "@brightspace-ui/core": "^1",
     "@brightspace-ui/htmleditor": "^1",
     "d2l-activities": "github:BrightspaceHypermediaComponents/activities#semver:^3",


### PR DESCRIPTION
This is the initial implementation of the `user-profile-card`'s UI/responsiveness as we are not getting any data from the backend yet

When hovering over/clicking the `user-context` component, the `user-profile-card` is displayed
The `user-profile-card` disappears when the user navigates their cursor off the `user-profile-card`

Notes: 
There isn't an option to hide the online/offline status so for the current implementation it'll be forever offline

![image](https://user-images.githubusercontent.com/32204301/106666813-181c8280-6576-11eb-9f08-28d44ba4ef50.png)
