### PR TITLE
US124534/mbosilj after download all sets files as read.

### DIFF
--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -201,8 +201,7 @@ export class ConsistentEvaluationSubmissionsPage extends SkeletonMixin(RtlMixin(
 		}
 	}
 
-	async _getSubmissionEntity(submissionHref) {
-		const byPassCache = false;
+	async _getSubmissionEntity(submissionHref, byPassCache = false) {
 		return await window.D2L.Siren.EntityStore.fetch(submissionHref, this._token, byPassCache);
 	}
 
@@ -390,7 +389,20 @@ export class ConsistentEvaluationSubmissionsPage extends SkeletonMixin(RtlMixin(
 			default:
 				this._deleteCookie();
 				this._downloading = false;
+				this._refreshAllSubmissionEntities();
 				break;
+		}
+	}
+
+	async _refreshAllSubmissionEntities() {
+		if (this._submissionList !== undefined) {
+			for (let i = 0; i < this._submissionList.length; i++) {
+				if (this._submissionList[i].href) {
+					const submission = await this._getSubmissionEntity(this._submissionList[i].href, true);
+					this._submissionEntities[i] = submission;
+				}
+			}
+			this.requestUpdate();
 		}
 	}
 


### PR DESCRIPTION
This was caused because we weren't updating the submissionEntities in the front end after modifying them in the backend.
Note the other way I could think of solving this was to have the front end loop through and update all the attachments in the submissionEntities. I chose instead to make another API call since the other way felt like a lot of computation for the front end and so we could ensure we didn't get inconsistent data in the front/back end.
Let me know if we'd rather avoid this API call!