### PR TITLE
Hide profile card if assignment is anonymous

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -646,6 +646,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 					user-href=${ifDefined(this.userHref)}
 					group-href=${ifDefined(this.groupHref)}
 					special-access-href=${ifDefined(this.specialAccessHref)}
+					.anonymousInfo=${this.anonymousInfo}
 					.token=${this.token}
 					.currentFileId=${this.currentFileId}
 					.submissionInfo=${this.submissionInfo}

--- a/components/header/d2l-consistent-evaluation-lcb-user-context.js
+++ b/components/header/d2l-consistent-evaluation-lcb-user-context.js
@@ -24,6 +24,10 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 				attribute: 'is-group-activity',
 				type: Boolean
 			},
+			anonymousInfo: {
+				attribute: false,
+				type: Object
+			},
 			enrolledUser: {
 				attribute: false,
 				type: Object
@@ -243,6 +247,10 @@ export class ConsistentEvaluationLcbUserContext extends EntityMixinLit(RtlMixin(
 			userProgressHref = this.enrolledUser.userProgressPath;
 			userProfileHref = this.enrolledUser.userProfilePath;
 			displayName = this.enrolledUser.displayName;
+		}
+
+		if (this.anonymousInfo && this.anonymousInfo.isAnonymous && !this.anonymousInfo.assignmentHasPublishedSubmission) {
+			return html ``;
 		}
 
 		return (this._showProfileCard && !this.isGroupActivity) ?

--- a/components/header/d2l-consistent-evaluation-learner-context-bar.js
+++ b/components/header/d2l-consistent-evaluation-learner-context-bar.js
@@ -23,6 +23,10 @@ export class ConsistentEvaluationLearnerContextBar extends SkeletonMixin(RtlMixi
 				attribute: 'special-access-href',
 				type: String
 			},
+			anonymousInfo: {
+				attribute: false,
+				type: Object
+			},
 			token: {
 				type: Object,
 				reflect: true,
@@ -151,6 +155,7 @@ export class ConsistentEvaluationLearnerContextBar extends SkeletonMixin(RtlMixi
 				<d2l-consistent-evaluation-lcb-user-context
 					.href=${this._getActorHref()}
 					.token=${this.token}
+					.anonymousInfo=${this.anonymousInfo}
 					.enrolledUser=${this.enrolledUser}
 					.groupInfo=${this.groupInfo}
 					?is-exempt=${this._getIsExempt()}


### PR DESCRIPTION
[US119337](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F412022776500&fdp=true?fdp=true): [UI] Make sure the username does not display when anonymous marking

The story description isn't entirely accurate as the designs indicate that we want to hide the entire card if the assignment is anonymous: https://d2lmail.sharepoint.com/:w:/r/sites/uxteam/_layouts/15/Doc.aspx?sourcedoc=%7B2001E110-38CE-4773-B7AA-19DDBC2E9235%7D&file=Anonymous%20Marking%20-%20Consistent%20Eval%20Specs.docx&action=default&mobileredirect=true

The rubrics popout already respects the anonymous name:
![rubrics_popup_is_anon](https://user-images.githubusercontent.com/11618509/109048866-9667d280-76a5-11eb-8739-36cabb8c25bf.png)
