### PR TITLE
US124816/DE42623 Limit submission items menus to submission list context

### DIFF
--- a/components/left-panel/consistent-evaluation-submission-item.js
+++ b/components/left-panel/consistent-evaluation-submission-item.js
@@ -472,7 +472,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeConsist
 	_addMenuOptions(read, flagged, downloadHref, id) {
 		const oppositeReadState = read ? this.localize('markUnread') : this.localize('markRead');
 		const oppositeFlagState = flagged ? this.localize('unflag') : this.localize('flag');
-		return html`<div slot="actions" style="z-index: inherit;">
+		return html`<div slot="actions">
 			<d2l-dropdown-more text="${this.localize('moreOptions')}">
 			<d2l-dropdown-menu id="dropdown" boundary="{&quot;right&quot;:10}">
 				<d2l-menu label="${this.localize('moreOptions')}">

--- a/components/left-panel/consistent-evaluation-submissions-page.js
+++ b/components/left-panel/consistent-evaluation-submissions-page.js
@@ -54,6 +54,8 @@ export class ConsistentEvaluationSubmissionsPage extends SkeletonMixin(RtlMixin(
 			:host {
 				background-color: var(--d2l-color-sylvite);
 				display: inline-block;
+				position: relative;
+				z-index: 1;
 			}
 			:host([hidden]) {
 				display: none;


### PR DESCRIPTION
Fix for US124816/DE42623, stop button from appearing on profile card without impacting `More Options` menu

![image](https://user-images.githubusercontent.com/50635849/109554415-2e98f980-7aa2-11eb-8145-4ddac5da8280.png)

Giving the `Submissions List` it's own [Stacking Context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) stops the popups from appearing over top of the profile card.