### PR TITLE
use getComposedActiveElement

### DIFF
--- a/components/right-panel/consistent-evaluation-grade-result.js
+++ b/components/right-panel/consistent-evaluation-grade-result.js
@@ -8,6 +8,7 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeConsistentEvaluation } from '../../lang/localize-consistent-evaluation.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 
 export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluation(LitElement) {
 
@@ -191,7 +192,7 @@ export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluatio
 		];
 
 		D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
-			/*               opener: */ document.body,
+			/*               opener: */ getComposedActiveElement(),
 			/*             location: */ location,
 			/*          srcCallback: */ 'SrcCallback',
 			/*       resizeCallback: */ '',
@@ -226,7 +227,7 @@ export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluatio
 		];
 
 		D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
-			/*               opener: */ document.body,
+			/*               opener: */ getComposedActiveElement(),
 			/*             location: */ location,
 			/*          srcCallback: */ 'SrcCallback',
 			/*       resizeCallback: */ '',

--- a/components/right-panel/consistent-evaluation-grade-result.js
+++ b/components/right-panel/consistent-evaluation-grade-result.js
@@ -5,10 +5,10 @@ import { html, LitElement } from 'lit-element';
 import { appId } from '../controllers/constants.js';
 import { createClient } from '@brightspace-ui/logging';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeConsistentEvaluation } from '../../lang/localize-consistent-evaluation.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
 
 export class ConsistentEvaluationGradeResult extends LocalizeConsistentEvaluation(LitElement) {
 


### PR DESCRIPTION
[DE42734](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fdefect%2F505877924612&fdp=true?fdp=true): Assignments > 20.21.03 > Dialog box A11y issues

As per suggestion by Dave B here: https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/109#discussion_r504909814

Please note this PR only fixed this issue from the defect: `when the dialog closes, the focus is at the top of the page not on the icon that was clicked, this makes it hard for a visually impaired user to know where they are and it take a lot of keystroke to get back to where they were.`

The point around dialogs closing with `esc` is to be done as part of a follow up story, as the logic is the same as in the old experience.