### PR TITLE
US124234: Prevent link attachments from opening in file viewer

### DIFF
--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -221,9 +221,15 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 			if (numberOfSubmittedFiles === 1) {
 				const isTiiEnabled = attachmentList.entities[0].hasSubEntityByRel(tiiRel);
 				if (!isTiiEnabled) {
-					const fileId = attachmentList.getSubEntityByClass(attachmentClassName).properties.id;
-					this.currentFileId = fileId;
-					return true;
+					const attachmentEntity = attachmentList.getSubEntityByClass(attachmentClassName);
+					// If the attachment is a link attachment, it should not be opened in the file viewer.
+					if (attachmentEntity.properties.extension && attachmentEntity.properties.extension.toLowerCase() === 'url') {
+						return false;
+					} else {
+						const fileId = attachmentEntity.properties.id;
+						this.currentFileId = fileId;
+						return true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When a student has only submitted 1 submission for an assignment, and that submission only has 1 attachment, the Assignment Evaluation page will automatically (on page load) open the attachment in the file viewer.

However, this should not happen for link attachments, which should always open in a new tab. Part of the reason is that when Audio/Video Note link attachments are opened in the file viewer, the Media Player will be shown inline. The Media Player currently has resizing and cutoff limitations inside of the file viewer, as shown below:

<img src="https://user-images.githubusercontent.com/9592685/112360868-28fd9080-8ca9-11eb-91e4-4d9cf9d9bfe8.png" height="350" />

This PR prevents the file viewer from automatically opening if there is 1 submission with 1 link attachment. Instead, the submissions list will be shown.