### PR TITLE
US124234: Fix error thrown when toggling 'read' or 'flagged' status for a text submission

### DIFF
--- a/components/left-panel/assignments/consistent-evaluation-submission-item.js
+++ b/components/left-panel/assignments/consistent-evaluation-submission-item.js
@@ -510,6 +510,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeConsist
 		const flagged = file.properties.flagged;
 		const read = file.properties.read;
 		const href = file.properties.href;
+		const extension = file.properties.extension;
 		const id = file.properties.id;
 		return html`
 		<d2l-list-item>
@@ -525,7 +526,7 @@ export class ConsistentEvaluationSubmissionItem extends RtlMixin(LocalizeConsist
 				<span class="d2l-body-small">${this._formatDateTime()}</span>
 			</div>
 		</d2l-list-item-content>
-		${this._addMenuOptions(read, flagged, href, id)}
+		${this._addMenuOptions(read, flagged, href, extension, id)}
 		</d2l-list-item>`;
 	}
 


### PR DESCRIPTION
This PR fixes an error thrown when the user tries to flag a text submission, or mark it as read. The error prevented the read/flagged status from being updated for text submissions.