### PR TITLE
Fix missing feedback attachment buttons

### DIFF
--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -152,8 +152,8 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				async() => {
 					const controller = new ConsistentEvaluationHrefController(this.href, this.token);
 					this._childHrefs = await controller.getHrefs();
-					this._rubricInfos = await controller.getRubricInfos(false);
 					this._activityType = await controller.getActivityType();
+					this._rubricInfos = await controller.getRubricInfos(false);
 					this._enrolledUser = await controller.getEnrolledUser();
 					this._groupInfo = await controller.getGroupInfo();
 					this._anonymousInfo = await controller.getAnonymousInfo();


### PR DESCRIPTION
Ensure we assign `_activityType` before populating any related infos

- fixes the issue where `_activityType` is set to `undefined` in `consistent-evaluation-page.js` (causing feedback attachments to not render)