### PR TITLE
US127007/show left skeleton when iterating.

### DIFF
--- a/components/left-panel/assignments/consistent-evaluation-evidence-assignment.js
+++ b/components/left-panel/assignments/consistent-evaluation-evidence-assignment.js
@@ -127,6 +127,10 @@ export class ConsistentEvaluationEvidenceAssignment extends SkeletonMixin(Locali
 	}
 
 	render() {
+		if (this.skeleton) {
+			return this._renderSubmissionList();
+		}
+
 		if (this.userProgressOutcomeHref) {
 			return this._renderOverallAchievement();
 		}


### PR DESCRIPTION
If the user is grading an assignment with the annotations viewer open and goes to the next student, this hides the annotation viewer and instead shows the submissions skeleton until the next students information loads.