### PR TITLE
US126243/clear filters if different discussionTopic.

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -115,6 +115,10 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 				attribute: 'discussion-calculation-type',
 				type: String
 			},
+			discussionTopicLink: {
+				attribute: 'discussion-topic-link',
+				type: String
+			},
 			navTitleInfo: {
 				attribute: false,
 				type: Object
@@ -343,6 +347,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 						user-progress-outcome-href=${ifDefined(this.userProgressOutcomeHref)}
 						download-all-submissions-location=${ifDefined(this.downloadAllSubmissionLink)}
 						activity-type=${this.activityType}
+						discussion-topic-link=${this.discussionTopicLink}
 						.currentFileId=${this.currentFileId}
 						.discussionPostList=${this.discussionPostList}
 						?hide-use-grade=${this._noGradeComponent()}

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -119,6 +119,7 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				edit-activity-path=${ifDefined(this._editActivityPath)}
 				activity-type=${this._activityType}
 				discussion-calculation-type=${ifDefined(this._discussionTopicInfo && this._discussionTopicInfo.calculationType)}
+				discussion-topic-link=${ifDefined(this._discussionTopicInfo && this._discussionTopicInfo.topicLink)}
 				.currentFileId=${this.currentFileId}
 				.rubricInfos=${this._rubricInfos}
 				.submissionInfo=${this._submissionInfo}

--- a/components/controllers/ConsistentEvaluationHrefController.js
+++ b/components/controllers/ConsistentEvaluationHrefController.js
@@ -109,10 +109,11 @@ export class ConsistentEvaluationHrefController {
 		let topicName = undefined;
 		let forumName = undefined;
 		let calculationType = undefined;
+		let topicLink = undefined;
 
 		if (root && root.entity) {
 			if (root.entity.hasLinkByRel(Rels.Discussions.topic)) {
-				const topicLink = root.entity.getLinkByRel(Rels.Discussions.topic).href;
+				topicLink = root.entity.getLinkByRel(Rels.Discussions.topic).href;
 				const topicResponse = await this._getEntityFromHref(topicLink, false);
 				if (topicResponse && topicResponse.entity) {
 					topicName = topicResponse.entity.properties.name;
@@ -130,7 +131,8 @@ export class ConsistentEvaluationHrefController {
 		return {
 			topicName,
 			forumName,
-			calculationType
+			calculationType,
+			topicLink
 		};
 	}
 	async getEditActivityPath() {

--- a/components/left-panel/consistent-evaluation-left-panel.js
+++ b/components/left-panel/consistent-evaluation-left-panel.js
@@ -23,6 +23,10 @@ export class ConsistentEvaluationLeftPanel extends SkeletonMixin(LocalizeConsist
 				attribute: 'display-conversion-warning',
 				type: Boolean
 			},
+			discussionTopicLink: {
+				attribute: 'discussion-topic-link',
+				type: String
+			},
 			downloadAllSubmissionLink: {
 				attribute: 'download-all-submissions-location',
 				type: String
@@ -77,6 +81,7 @@ export class ConsistentEvaluationLeftPanel extends SkeletonMixin(LocalizeConsist
 		return html`
 			<d2l-consistent-evaluation-evidence-discussion
 				?skeleton=${this.skeleton}
+				discussion-topic-link=${this.discussionTopicLink}
 				.discussionPostList=${this.discussionPostList}
 				.token=${this.token}
 			></d2l-consistent-evaluation-evidence-discussion>

--- a/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
+++ b/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
@@ -19,6 +19,10 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 				attribute: false,
 				type: Array
 			},
+			discussionTopicLink: {
+				attribute: 'discussion-topic-link',
+				type: String
+			},
 			token: { type: Object },
 			_sortingMethod: {
 				attribute: false,
@@ -108,6 +112,12 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 			${this._renderUnscoredStatus()}
 			${this._renderDiscussionPost()}
 		`;
+	}
+	async updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('discussionTopicLink')) {
+			this._clearFilters();
+		}
 	}
 	_clearFilters() {
 		this._selectedPostFilters = [];

--- a/test/ConsistentEvaluationHrefController.test.js
+++ b/test/ConsistentEvaluationHrefController.test.js
@@ -403,6 +403,7 @@ describe('ConsistentEvaluationHrefController', () => {
 			const disucssionTopicInfo = await controller.getDiscussionTopicInfo();
 			assert.equal(disucssionTopicInfo.topicName, expectedTopicName);
 			assert.equal(disucssionTopicInfo.calculationType, expectedCalculationType);
+			assert.equal(disucssionTopicInfo.topicLink, topicHref);
 		});
 	});
 


### PR DESCRIPTION
Note this currently doesn't do anything but when we eventually allow users to iterate between different discussion topics the filters should clear themselves