### PR TITLE
US127307 Added null check for data telemetry endpoint

### DIFF
--- a/components/helpers/consistent-eval-telemetry.js
+++ b/components/helpers/consistent-eval-telemetry.js
@@ -38,7 +38,7 @@ export class ConsistentEvalTelemetry {
 	}
 
 	async _logUserEvent(href, action, type, performanceMeasureName, activityType, submissionCount) {
-		if (!href || !action || !type || !performanceMeasureName) { return; }
+		if (!href || !action || !type || !performanceMeasureName || !this._dataTelemetryEndpoint) { return; }
 		const eventBody = new Events.PerformanceEventBody()
 			.setAction(action)
 			.setObject(href, type)


### PR DESCRIPTION
### Motivation/Context
* As part of the PBMM work we need to ensure we do not log telemetry events for Protected B clients so the case where data telemetry endpoint could be `null` is more likely to happen now. Through testing, it's found that consistent-evaluation would throw a 500 POST error when that happens, this PR is aimed to fix that 500 error.

Related PR: https://github.com/Brightspace/lms/pull/10201

### Summary of Changes
* When data telemetry endpoint is null, no network request is created to log the telemetry event

### Rally Story
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600523947568&fdp=true?fdp=true