### PR TITLE
Add tabindex and keyboard accessibility to mobile drawer

### DIFF
--- a/components/right-panel/consistent-evaluation-right-panel-block.js
+++ b/components/right-panel/consistent-evaluation-right-panel-block.js
@@ -111,10 +111,18 @@ class ConsistentEvaluationRightPanelBlock extends LitElement {
 		}
 	}
 
+	_onKeydownHandler(e) {
+		if (e.key === 'Enter' || e.key === ' ') {
+			this._toggleOpenDialog();
+		}
+	}
+
 	_renderListItems() {
 		return html`
 			<d2l-list-item class="d2l-list-item"
-				@click=${this._toggleOpenDialog}>
+				tabindex="0"
+				@click=${this._toggleOpenDialog}
+				@keydown=${this._onKeydownHandler}>
 				<d2l-list-item-content class="d2l-list-item-content">
 					${this._getTitle()}
 					<div class="d2l-truncate" slot="supporting-info">${this.supportingInfo}</div>


### PR DESCRIPTION
Allows users to tab into the mobile drawer of CE and press `Enter` or `Space` to open the dialog