### PR TITLE
feat: Set include-statistics attribute for inline rubric

### DIFF
--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -221,6 +221,7 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(RtlMixin(L
 						?force-compact=${!this.isPopout}
 						overall-score-flag
 						selected
+						include-statistics
 						@d2l-rubric-total-score-changed=${this._syncActiveScoringRubricGradeHandler}
 					></d2l-rubric>
 				</div>


### PR DESCRIPTION
Allows the rubric statistics button from the old evaluation experience to be included, if a link is also provided by the API.

https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F508482042404