### PR TITLE
feat: add rubrics inline grading revamp toggle attribute

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -154,6 +154,10 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 				attribute: 'use-new-html-editor',
 				type: Boolean
 			},
+			useInlineGradingRevamp: {
+				attribute: 'use-inline-grading-revamp',
+				type: Boolean
+			},
 			displayConversionWarning: {
 				attribute: 'display-conversion-warning',
 				type: Boolean
@@ -401,6 +405,7 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 						?allow-record-audio=${canRecordFeedbackAudio}
 						?skeleton=${this.skeleton}
 						?use-new-html-editor=${this.useNewHtmlEditor}
+						?use-inline-grading-revamp=${this.useInlineGradingRevamp}
 						@on-d2l-consistent-eval-feedback-edit=${this._transientSaveFeedback}
 						@on-d2l-consistent-eval-feedback-attachments-add=${this._transientAddAttachment}
 						@on-d2l-consistent-eval-feedback-attachments-remove=${this._transientRemoveAttachment}

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -35,6 +35,10 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				attribute: 'use-new-html-editor',
 				type: Boolean
 			},
+			useInlineGradingRevamp: {
+				attribute: 'use-inline-grading-revamp',
+				type: Boolean
+			},
 			displayConversionWarning: {
 				attribute: 'display-conversion-warning',
 				type: Boolean
@@ -143,6 +147,7 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				?rubric-read-only=${this._rubricReadOnly}
 				?hide-learner-context-bar=${this._shouldHideLearnerContextBar()}
 				?use-new-html-editor=${this.useNewHtmlEditor}
+				?use-inline-grading-revamp=${this.useInlineGradingRevamp}
 				?display-conversion-warning=${this.displayConversionWarning}
 				@d2l-consistent-evaluation-previous-student-click=${this._onPreviousStudentClick}
 				@d2l-consistent-evaluation-next-student-click=${this._onNextStudentClick}

--- a/components/right-panel/consistent-evaluation-right-panel.js
+++ b/components/right-panel/consistent-evaluation-right-panel.js
@@ -103,6 +103,10 @@ export class ConsistentEvaluationRightPanel extends SkeletonMixin(LocalizeConsis
 				attribute: 'use-new-html-editor',
 				type: Boolean
 			},
+			useInlineGradingRevamp: {
+				attribute: 'use-inline-grading-revamp',
+				type: Boolean
+			},
 			discussionCalulationType: {
 				attribute: 'discussion-calculation-type',
 				type: String
@@ -393,6 +397,7 @@ export class ConsistentEvaluationRightPanel extends SkeletonMixin(LocalizeConsis
 					?show-active-scoring-rubric-options=${showActiveScoringRubric}
 					?read-only=${this.rubricReadOnly}
 					?can-save-overall-grade=${this.canSaveOverallGrade}
+					?use-inline-grading-revamp=${this.useInlineGradingRevamp}
 					@d2l-consistent-eval-rubric-total-score-changed=${this._syncGradeToRubricScore}
 					@d2l-consistent-eval-active-scoring-rubric-change=${this._updateScoreWithActiveScoringRubric}
 					@d2l-rubric-compact-expanded-changed=${this._updateRubricOpenState}

--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -44,6 +44,10 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(RtlMixin(L
 			canSaveOverallGrade: {
 				attribute: 'can-save-overall-grade',
 				type: Boolean
+			},
+			useInlineGradingRevamp: {
+				attribute: 'use-inline-grading-revamp',
+				type: Boolean
 			}
 		};
 	}
@@ -221,6 +225,7 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(RtlMixin(L
 						?force-compact=${!this.isPopout}
 						overall-score-flag
 						selected
+						legacy=${!this.useInlineGradingRevamp}
 						@d2l-rubric-total-score-changed=${this._syncActiveScoringRubricGradeHandler}
 					></d2l-rubric>
 				</div>


### PR DESCRIPTION
Rally: [US129073](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F601565647541)

Enables toggling between the inline grading revamp and the legacy experience via the `useInlineGradingRevamp` attribute on `<d2l-consistent-evaluation>`. See [Brightspace/lms#11459](https://github.com/Brightspace/lms/pull/11459) and [Brightspace/d2l-rubric#816](https://github.com/Brightspace/d2l-rubric/pull/816) for more details.