### PR TITLE
fix: bind inline rubrics revamp flag to boolean attribute

### DIFF
--- a/components/right-panel/consistent-evaluation-rubric.js
+++ b/components/right-panel/consistent-evaluation-rubric.js
@@ -225,7 +225,7 @@ class ConsistentEvaluationRubric extends LocalizeConsistentEvaluation(RtlMixin(L
 						?force-compact=${!this.isPopout}
 						overall-score-flag
 						selected
-						legacy=${!this.useInlineGradingRevamp}
+						?legacy=${!this.useInlineGradingRevamp}
 						include-statistics
 						@d2l-rubric-total-score-changed=${this._syncActiveScoringRubricGradeHandler}
 					></d2l-rubric>


### PR DESCRIPTION
Rally: [US129073](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F601565647541)

`legacy` attribute was being passed to the inline rubric component as a string instead of a boolean, which was forcing the legacy experience on for all instances of grading mode