### PR TITLE
Update rubric assessment demo/test data

### DIFF
--- a/demo/consistent-evaluation-rubrics.html
+++ b/demo/consistent-evaluation-rubrics.html
@@ -37,7 +37,7 @@
 			}
 		</style>
 	</head>
-	<body unresolved>
+	<body>
 		<d2l-demo-page page-title="consistent-evaluation-rubric">
 
 			<h2>Single Rubric</h2>

--- a/demo/consistent-evaluation-rubrics.html
+++ b/demo/consistent-evaluation-rubrics.html
@@ -37,7 +37,7 @@
 			}
 		</style>
 	</head>
-	<body>
+	<body unresolved>
 		<d2l-demo-page page-title="consistent-evaluation-rubric">
 
 			<h2>Single Rubric</h2>

--- a/demo/data/rubric/198/assessment/8.json
+++ b/demo/data/rubric/198/assessment/8.json
@@ -1,128 +1,137 @@
 {
-  "class":[
+  "class": [
     "rubric-result",
     "completed"
   ],
-  "properties":{
-    "score":12
+  "properties": {
+    "score": 12
   },
-  "entities":[
+  "entities": [
     {
-      "class":[
+      "class": [
         "richtext",
         "overall-feedback"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "properties":{
-        "text":"",
-        "html":""
+      "properties": {
+        "text": "",
+        "html": ""
       }
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/620.json"
+          "href": "data/rubric/198/groups/175/criteria/620.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/620.json"
+          "href": "data/rubric/198/assessment/8/criterion/620.json"
         }
       ]
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/621.json"
+          "href": "data/rubric/198/groups/175/criteria/621.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/621.json"
+          "href": "data/rubric/198/assessment/8/criterion/621.json"
         }
       ]
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/622.json"
+          "href": "data/rubric/198/groups/175/criteria/622.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/622.json"
+          "href": "data/rubric/198/assessment/8/criterion/622.json"
         }
       ]
     }
   ],
-  "links":[
+  "links": [
     {
-      "rel":[
+      "rel": [
         "self"
       ],
-      "href":"data/rubric/198/assessment/8.json"
+      "href": "data/rubric/198/assessment/8.json"
     },
     {
-      "rel":[
+      "class": [
+        "activity-statistics"
+      ],
+      "rel": [
+        "rubric-assessment-stats"
+      ],
+      "href": "data/rubric/198/assessment/8/stats.html"
+    },
+    {
+      "rel": [
         "https://api.brightspace.com/rels/rubric"
       ],
-      "href":"data/rubric/198.json"
+      "href": "data/rubric/198.json"
     },
     {
-      "rel":[
+      "rel": [
         "https://api.brightspace.com/rels/user"
       ],
-      "href":"data/rubric/198.json"
+      "href": "data/rubric/198.json"
     }
   ]
 }

--- a/demo/data/rubric/198/assessment/8/stats.html
+++ b/demo/data/rubric/198/assessment/8/stats.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+</head>
+
+<body>
+	<p>Rubric Statistics</p>
+</body>
+
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.141.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.141.0.tgz",
-      "integrity": "sha512-XyMoSvprxw/kVvxXubTOwPlOpjTKhbsDDJOMhBFJXhrn0u8asRh+PoYDDuGv823k4o4fUtV7XVpfMgcp8qMzsQ==",
+      "version": "1.142.1",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.142.1.tgz",
+      "integrity": "sha512-bT2mxcVT/JiCZasHq5Y9UPe4R6djyYdPXv9qUZme8s9qPDHv8AkPFMUrLjtpecuSM/ekLWE1JXRVJ9CHjEe50g==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -4611,7 +4611,7 @@
       }
     },
     "d2l-rubric": {
-      "version": "github:Brightspace/d2l-rubric#c0fd28ee3b0c77d294b5a3fe6ec583b6bba75e3c",
+      "version": "github:Brightspace/d2l-rubric#061ac6673244af8b8f2220ba8d784def88822d1a",
       "from": "github:Brightspace/d2l-rubric#semver:^3",
       "requires": {
         "@brightspace-ui-labs/accordion": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:lit": "lit-analyzer consistent-evaluation.js components demo test",
     "lint:style": "stylelint \"**/*.js\"",
-    "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
+    "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --preserve-symlinks --open --watch",
     "test": "npm run lint && npm run test:headless",
     "test:headless": "karma start",
     "test:headless:watch": "karma start --auto-watch=true --single-run=false",

--- a/test/perceptual/data/rubric/198/assessment/8.json
+++ b/test/perceptual/data/rubric/198/assessment/8.json
@@ -1,128 +1,137 @@
 {
-  "class":[
+  "class": [
     "rubric-result",
     "completed"
   ],
-  "properties":{
-    "score":12
+  "properties": {
+    "score": 12
   },
-  "entities":[
+  "entities": [
     {
-      "class":[
+      "class": [
         "richtext",
         "overall-feedback"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "properties":{
-        "text":"",
-        "html":""
+      "properties": {
+        "text": "",
+        "html": ""
       }
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/620.json"
+          "href": "data/rubric/198/groups/175/criteria/620.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/620.json"
+          "href": "data/rubric/198/assessment/8/criterion/620.json"
         }
       ]
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/621.json"
+          "href": "data/rubric/198/groups/175/criteria/621.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/621.json"
+          "href": "data/rubric/198/assessment/8/criterion/621.json"
         }
       ]
     },
     {
-      "class":[
+      "class": [
         "criterion-assessment-links"
       ],
-      "rel":[
+      "rel": [
         "item"
       ],
-      "links":[
+      "links": [
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criteria-group"
           ],
-          "href":"data/rubric/198/groups/175.json"
+          "href": "data/rubric/198/groups/175.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://rubrics.api.brightspace.com/rels/criterion"
           ],
-          "href":"data/rubric/198/groups/175/criteria/622.json"
+          "href": "data/rubric/198/groups/175/criteria/622.json"
         },
         {
-          "rel":[
+          "rel": [
             "https://assessments.api.brightspace.com/rels/assessment-criterion"
           ],
-          "href":"data/rubric/198/assessment/8/criterion/622.json"
+          "href": "data/rubric/198/assessment/8/criterion/622.json"
         }
       ]
     }
   ],
-  "links":[
+  "links": [
     {
-      "rel":[
+      "rel": [
         "self"
       ],
-      "href":"data/rubric/198/assessment/8.json"
+      "href": "data/rubric/198/assessment/8.json"
     },
     {
-      "rel":[
+      "class": [
+        "activity-statistics"
+      ],
+      "rel": [
+        "rubric-assessment-stats"
+      ],
+      "href": "data/rubric/198/assessment/8/stats.html"
+    },
+    {
+      "rel": [
         "https://api.brightspace.com/rels/rubric"
       ],
-      "href":"data/rubric/198.json"
+      "href": "data/rubric/198.json"
     },
     {
-      "rel":[
+      "rel": [
         "https://api.brightspace.com/rels/user"
       ],
-      "href":"data/rubric/198.json"
+      "href": "data/rubric/198.json"
     }
   ]
 }

--- a/test/perceptual/data/rubric/198/assessment/8/stats.html
+++ b/test/perceptual/data/rubric/198/assessment/8/stats.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+</head>
+
+<body>
+	<p>Rubric Statistics</p>
+</body>
+
+</html>


### PR DESCRIPTION
This updates the rubric result to include the statistics link. This was added recently. This also updates to latest `d2l-rubric` and `@brightspace-ui/core` and adds `--preserve-symlinks` to demo runner so you can `npm link` in stuff if needed for testing.