### PR TITLE
♿️ Add aria label for discussions link

### DIFF
--- a/components/left-panel/discussions/consistent-evaluation-discussion-evidence-body.js
+++ b/components/left-panel/discussions/consistent-evaluation-discussion-evidence-body.js
@@ -231,9 +231,11 @@ export class ConsistentEvaluationDiscussionEvidenceBody extends RtlMixin(Localiz
 		}
 	}
 	_renderTitle() {
+		const labelText = `${this.postTitle} (${this.localize('opensInANewTab')})`;
 		return html `
 		<h2 class="d2l-body-compact d2l-consistent-evaluation-discussion-evidence-body-title">
 			<a
+				aria-label=${labelText}
 				class="d2l-link"
 				tabindex="0"
 				@click=${this._onPostTitleClicked}

--- a/lang/en.js
+++ b/lang/en.js
@@ -78,6 +78,7 @@ export default {
 	"ok": "OK",
 	"oldestFirst": "Oldest First",
 	"openPopoutRubric": "Open popout rubric",
+	"opensInANewTab": "opens in a new tab",
 	"outcomesSummary" : "{outcome, select, competencies {Competencies} expectations {Expectations} objectives {Objectives} outcomes {Outcomes} standards {Standards} other {Standards}} aligned",
 	"outcomeTerm": "{outcome, select, competencies {Competencies} expectations {Expectations} objectives {Objectives} outcomes {Outcomes} standards {Standards} other {Standards}}",
 	"overallAchievement": "Overall Achievement",


### PR DESCRIPTION
Discussion post titles will now read "`{postTitle} (opens in a new tab)`" for screen-reader users