### PR TITLE
US129373 - fixing clear filter bug

### DIFF
--- a/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
+++ b/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
@@ -138,6 +138,7 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 
 	_clearFilters() {
 		this._selectedFilters = [];
+		this._displayedDiscussionPostObjects = undefined;
 	}
 
 	_countPostFilters() {


### PR DESCRIPTION
Fixes [US129373](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F602338301313)

Missed resetting a variable when filters are cleared, so the displayed posts weren't getting updated!