### PR TITLE
DE44005 - Fix annotations full screen

### DIFF
--- a/components/left-panel/assignments/consistent-evaluation-evidence-file.js
+++ b/components/left-panel/assignments/consistent-evaluation-evidence-file.js
@@ -70,6 +70,7 @@ export class ConsistentEvaluationEvidenceFile extends LocalizeConsistentEvaluati
 		return html`
 			<d2l-consistent-evaluation-evidence-top-bar></d2l-consistent-evaluation-evidence-top-bar>
 			<iframe
+				src="${this.url}"
 				id="d2l-annotations-iframe"
 				?data-resizing=${this._resizing}
 				frameborder="0"


### PR DESCRIPTION
[DE44005](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fdefect%2F601856333077&fdp=true?fdp=true): Assignment>20.21.5 & 20.21.6>Maximize Annotations window not responding

Add back src attribute that was removed here: https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/commit/2d92e7bfdd09a410bf793931247ebb23194900e2#diff-8d6e4a8c5b24f138e7dc1b963ca992db596d7c3bf70713bf55cd6886ba47c207

Jamie and I chatted re: context of this, and I followed up with Dale and Megan. They're comfortable with proceeding.