### PR TITLE
US129385 - solving discussions table flicker on load

### DIFF
--- a/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
+++ b/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
@@ -115,19 +115,22 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 	}
 
 	render() {
-		if (this.discussionPostList && this.discussionPostList.length === 0 && !this.skeleton) {
-			this._finishedLoading();
-			return html`${this._renderNoAssessablePosts()}`;
-		}
 
 		if (this.discussionPostList && typeof this._displayedDiscussionPostObjects === 'undefined') {
 			this._getDiscussionPostEntities().then(() => this.requestUpdate());
 		}
 
-		return html`
-			${this._renderListModifiers()}
-			${this._renderDiscussionPost()}
-		`;
+		if (this.discussionPostList && this.discussionPostList.length === 0 && !this.skeleton) {
+			this._finishedLoading();
+			return html`${this._renderNoAssessablePosts()}`;
+		}
+		
+		if (this._displayedDiscussionPostObjects && this._displayedDiscussionPostObjects.length > 0) {
+			return html`
+				${this._renderListModifiers()}
+				${this._renderDiscussionPost()}
+			`;
+		}
 	}
 
 	async updated(changedProperties) {

--- a/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
+++ b/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
@@ -119,22 +119,12 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 		if (this.discussionPostList && typeof this._displayedDiscussionPostObjects === 'undefined') {
 			this._getDiscussionPostEntities().then(() => {
 				this.requestUpdate();
-				return html`
-					${this._renderListModifiers()}
-					${this._renderDiscussionPost()}
-				`;
+				return this._renderDiscussionPosts();
 			});
 		} else {
-			return html`
-				${this._renderListModifiers()}
-				${this._renderDiscussionPost()}
-			`;
+			return this._renderDiscussionPosts();
 		}
 
-		if (this.discussionPostList && this.discussionPostList.length === 0 && !this.skeleton) {
-			this._finishedLoading();
-			return html`${this._renderNoAssessablePosts()}`;
-		}
 	}
 
 	async updated(changedProperties) {
@@ -298,7 +288,7 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 		}
 	}
 
-	_renderDiscussionPost() {
+	_renderDiscussionPostPage() {
 		return html`
 			<d2l-consistent-evaluation-discussion-post-page
 				?skeleton=${this.skeleton}
@@ -307,6 +297,17 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 				.token=${this.token}
 				.filteringStatus=${this._filteringStatus}
 			></d2l-consistent-evaluation-discussion-post-page>
+		`;
+	}
+	_renderDiscussionPosts() {
+		if (this.discussionPostList && this.discussionPostList.length === 0 && !this.skeleton) {
+			this._finishedLoading();
+			return html`${this._renderNoAssessablePosts()}`;
+		}
+
+		return html`
+			${this._renderListModifiers()}
+			${this._renderDiscussionPostPage()}
 		`;
 	}
 	_renderFilterDropDownList() {

--- a/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
+++ b/components/left-panel/discussions/consistent-evaluation-evidence-discussion.js
@@ -117,19 +117,23 @@ export class ConsistentEvaluationEvidenceDiscussion extends SkeletonMixin(RtlMix
 	render() {
 
 		if (this.discussionPostList && typeof this._displayedDiscussionPostObjects === 'undefined') {
-			this._getDiscussionPostEntities().then(() => this.requestUpdate());
+			this._getDiscussionPostEntities().then(() => {
+				this.requestUpdate();
+				return html`
+					${this._renderListModifiers()}
+					${this._renderDiscussionPost()}
+				`;
+			});
+		} else {
+			return html`
+				${this._renderListModifiers()}
+				${this._renderDiscussionPost()}
+			`;
 		}
 
 		if (this.discussionPostList && this.discussionPostList.length === 0 && !this.skeleton) {
 			this._finishedLoading();
 			return html`${this._renderNoAssessablePosts()}`;
-		}
-		
-		if (this._displayedDiscussionPostObjects && this._displayedDiscussionPostObjects.length > 0) {
-			return html`
-				${this._renderListModifiers()}
-				${this._renderDiscussionPost()}
-			`;
 		}
 	}
 


### PR DESCRIPTION
Fixes [US129385 ](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F602368931165) by waiting until `_getDiscussionPostEntities()` finishes fetching the discussion posts before trying to render the table!