### PR TITLE
Fix: saving evaluation would populate discussion post scores with old grades

### DIFF
--- a/components/consistent-evaluation-page.js
+++ b/components/consistent-evaluation-page.js
@@ -1009,6 +1009,14 @@ export default class ConsistentEvaluationPage extends SkeletonMixin(LocalizeCons
 					const discussionPostsEntity = this.evaluationEntity.getSubEntityByRel(evidenceRel);
 					if (discussionPostsEntity) {
 						this.discussionPostList = discussionPostsEntity.getSubEntitiesByClass(postClass);
+
+						this.dispatchEvent(new CustomEvent('d2l-consistent-eval-on-post-score-transient-save', {
+							composed: true,
+							bubbles: true,
+							detail: {
+								discussionPostList: this.discussionPostList
+							}
+						}));
 					}
 				}
 			}

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -173,7 +173,7 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				@d2l-consistent-evaluation-loading-finished=${this._finishedLoading}
 				@d2l-consistent-eval-rubric-popup-closed=${this._refreshRubrics}
 				@d2l-consistent-eval-on-evaluation-save=${this._refreshRubrics}
-				@d2l-consistent-eval-on-post-score-transient-save=${this._updatePostScores}
+				@d2l-consistent-eval-on-post-score-transient-save=${this._updateDiscussionPostList}
 			></d2l-consistent-evaluation-page>
 		`;
 	}
@@ -418,7 +418,7 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 		}
 	}
 
-	_updatePostScores(e) {
+	_updateDiscussionPostList(e) {
 		if (e.detail && e.detail.discussionPostList) {
 			this._discussionPostList = e.detail.discussionPostList;
 		}

--- a/components/consistent-evaluation.js
+++ b/components/consistent-evaluation.js
@@ -172,7 +172,8 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 				@d2l-consistent-evaluation-next-student-click=${this._onNextStudentClick}
 				@d2l-consistent-evaluation-loading-finished=${this._finishedLoading}
 				@d2l-consistent-eval-rubric-popup-closed=${this._refreshRubrics}
-				@d2l-consistent-eval-on-evaluation-save=${this._refreshInfos}
+				@d2l-consistent-eval-on-evaluation-save=${this._refreshRubrics}
+				@d2l-consistent-eval-on-post-score-transient-save=${this._updatePostScores}
 			></d2l-consistent-evaluation-page>
 		`;
 	}
@@ -356,17 +357,6 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 			}
 		);
 	}
-	async _refreshDiscussionPosts() {
-		const controller = new ConsistentEvaluationHrefController(this.href, this.token);
-		this._discussionPostList = await controller.getDiscussionPostsInfo();
-	}
-
-	async _refreshInfos() {
-		if (this._activityType === discussionActivity) {
-			this._refreshDiscussionPosts();
-		}
-		this._refreshRubrics();
-	}
 
 	async _refreshRubrics() {
 		const controller = new ConsistentEvaluationHrefController(this.href, this.token);
@@ -425,6 +415,12 @@ export class ConsistentEvaluation extends LocalizeConsistentEvaluation(LitElemen
 
 				window.history.replaceState(null, null, currentUrl.toString());
 			}
+		}
+	}
+
+	_updatePostScores(e) {
+		if (e.detail && e.detail.discussionPostList) {
+			this._discussionPostList = e.detail.discussionPostList;
 		}
 	}
 }


### PR DESCRIPTION
#588 re-introduced a bug where saving evaluation would populate discussion post scores with old grades

`_refreshDiscussionPosts()` was periodically fetching the old `post-scores` due to a race condition with our transient-save. Fixed this by updating the discussion list `on-transient-save`  instead of re-fetching